### PR TITLE
Dev: refactoring unit-tests for rclc executor

### DIFF
--- a/rclc/CMakeLists.txt
+++ b/rclc/CMakeLists.txt
@@ -67,7 +67,6 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   set(ament_cmake_copyright_FOUND TRUE) # No copyright header check since link to NOTICE file is not recognized properly.
-  find_package(geometry_msgs REQUIRED)
   find_package(osrf_testing_tools_cpp REQUIRED)
   find_package(std_msgs REQUIRED)
   ament_lint_auto_find_test_dependencies()
@@ -90,7 +89,6 @@ if(BUILD_TESTING)
     rosidl_generator_c
     osrf_testing_tools_cpp
     std_msgs
-    geometry_msgs
   )
 endif()
 

--- a/rclc/package.xml
+++ b/rclc/package.xml
@@ -23,7 +23,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>osrf_testing_tools_cpp</test_depend>
   <test_depend>std_msgs</test_depend>
-  <test_depend>geometry_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rclc/test/test_executor.cpp
+++ b/rclc/test/test_executor.cpp
@@ -185,7 +185,7 @@ _executor_results_compare(unsigned int * array)
 
 // definition of callbacks
 #define INT_CALLBACK_DEFINITION(NUM) \
-  void int32_callback ## NUM(const void * msgin) \
+  void int32_callback_ ## NUM(const void * msgin) \
   { \
     const std_msgs__msg__Int32 * msg = (const std_msgs__msg__Int32 *)msgin; \
     if (msg == NULL) { \
@@ -201,49 +201,10 @@ _executor_results_compare(unsigned int * array)
 #define INT_CALLBACK(NUM) \
   int32_callback_ ## NUM
 
-
-INT_CALLBACK_DEFINITION(1)
-INT_CALLBACK_DEFINITION(2)
-INT_CALLBACK_DEFINITION(3)
-
-/*
-void int32_callback1(const void * msgin)
-{
-  const std_msgs__msg__Int32 * msg = (const std_msgs__msg__Int32 *)msgin;
-  if (msg == NULL) {
-    printf("Test CB: msg NULL\n");
-  } else {
-    // printf("Test CB 1: msg %d\n", msg->data);
-  }
-  _cb1_cnt++;
-  _executor_results_add(1);
-}
-
-
-void int32_callback2(const void * msgin)
-{
-  const std_msgs__msg__Int32 * msg = (const std_msgs__msg__Int32 *)msgin;
-  if (msg == NULL) {
-    printf("Test CB: msg NULL\n");
-  } else {
-    // printf("Test CB 2: msg %d\n", msg->data);
-  }
-  _cb2_cnt++;
-  _executor_results_add(2);
-}
-
-void int32_callback3(const void * msgin)
-{
-  const std_msgs__msg__Int32 * msg = (const std_msgs__msg__Int32 *)msgin;
-  if (msg == NULL) {
-    printf("Test CB: msg NULL\n");
-  } else {
-    // printf("Test CB 3: msg %d\n", msg->data);
-  }
-  _cb3_cnt++;
-  _executor_results_add(3);
-}
-*/
+// macro-definition               definition of callback function
+INT_CALLBACK_DEFINITION(1)  // => int32_callback_1
+INT_CALLBACK_DEFINITION(2)  // => int32_callback_2
+INT_CALLBACK_DEFINITION(3)  // => int32_callback_3
 
 // for test case semantics
 void int32_callback4(const void * msgin)
@@ -363,6 +324,30 @@ void my_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
   }
 }
 
+#define CREATE_PUBLISHER(PUB, TOPIC_NAME) \
+  this->PUB = rcl_get_zero_initialized_publisher(); \
+  this->PUB ## _topic_name = #TOPIC_NAME; \
+  this->PUB ## _type_support = \
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32); \
+  this->PUB ## _options = rcl_publisher_get_default_options(); \
+  ret = rcl_publisher_init(&this->PUB, &this->node, this->PUB ## _type_support, \
+      this->PUB ## _topic_name, &this->PUB ## _options); \
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str; \
+  rcl_reset_error();
+
+#define CREATE_SUBSCRIPTION(SUB, TOPIC_NAME) \
+  this->SUB = rcl_get_zero_initialized_subscription(); \
+  this->SUB ## _topic_name = #TOPIC_NAME; \
+  this->SUB ## _type_support = \
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32); \
+  this->SUB ## _options = rcl_subscription_get_default_options(); \
+  ret = rcl_subscription_init(&this->SUB, &this->node, this->SUB ## _type_support, \
+      this->SUB ## _topic_name, &this->SUB ## _options); \
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str; \
+  EXPECT_TRUE(rcl_subscription_is_valid(&this->SUB)); \
+  rcl_reset_error();
+
+
 class TestDefaultExecutor : public ::testing::Test
 {
 public:
@@ -370,49 +355,48 @@ public:
   rcl_node_t node;
 
   // integer publisher 1
-  rcl_publisher_t pub1_int;
-  const char * pub1_int_topic_name;
-  const rosidl_message_type_support_t * pub1_int_type_support;
-  rcl_publisher_options_t pub1_int_options;
-  std_msgs__msg__Int32 pub1_int_msg;
+  rcl_publisher_t pub1;
+  const char * pub1_topic_name;
+  const rosidl_message_type_support_t * pub1_type_support;
+  rcl_publisher_options_t pub1_options;
+  std_msgs__msg__Int32 pub1_msg;
 
   // integer publisher 2
-  rcl_publisher_t pub2_int;
-  const char * pub2_int_topic_name;
-  const rosidl_message_type_support_t * pub2_int_type_support;
-  rcl_publisher_options_t pub2_int_options;
-  std_msgs__msg__Int32 pub2_int_msg;
+  rcl_publisher_t pub2;
+  const char * pub2_topic_name;
+  const rosidl_message_type_support_t * pub2_type_support;
+  rcl_publisher_options_t pub2_options;
+  std_msgs__msg__Int32 pub2_msg;
 
   // integer publisher 3
-  rcl_publisher_t pub3_int;
-  const char * pub3_int_topic_name;
-  const rosidl_message_type_support_t * pub3_int_type_support;
-  rcl_publisher_options_t pub3_int_options;
-  std_msgs__msg__Int32 pub3_int_msg;
+  rcl_publisher_t pub3;
+  const char * pub3_topic_name;
+  const rosidl_message_type_support_t * pub3_type_support;
+  rcl_publisher_options_t pub3_options;
+  std_msgs__msg__Int32 pub3_msg;
 
   // integer subscription 1
-  rcl_subscription_t sub1_int;
-  const char * sub1_int_topic_name;
-  const rosidl_message_type_support_t * sub1_int_type_support;
-  rcl_subscription_options_t sub1_int_options;
-  std_msgs__msg__Int32 sub1_int_msg;
+  rcl_subscription_t sub1;
+  const char * sub1_topic_name;
+  const rosidl_message_type_support_t * sub1_type_support;
+  rcl_subscription_options_t sub1_options;
+  std_msgs__msg__Int32 sub1_msg;
 
   // integer subscription 2
-  rcl_subscription_t sub2_int;
-  const char * sub2_int_topic_name;
-  const rosidl_message_type_support_t * sub2_int_type_support;
-  rcl_subscription_options_t sub2_int_options;
-  std_msgs__msg__Int32 sub2_int_msg;
+  rcl_subscription_t sub2;
+  const char * sub2_topic_name;
+  const rosidl_message_type_support_t * sub2_type_support;
+  rcl_subscription_options_t sub2_options;
+  std_msgs__msg__Int32 sub2_msg;
 
   // integer subscription 3
-  rcl_subscription_t sub3_int;
-  const char * sub3_int_topic_name;
-  const rosidl_message_type_support_t * sub3_int_type_support;
-  rcl_subscription_options_t sub3_int_options;
-  std_msgs__msg__Int32 sub3_int_msg;
+  rcl_subscription_t sub3;
+  const char * sub3_topic_name;
+  const rosidl_message_type_support_t * sub3_type_support;
+  rcl_subscription_options_t sub3_options;
+  std_msgs__msg__Int32 sub3_msg;
 
   // timer 1
-  // TODO(Jan) remove pointer to avoid dynamic memory allocation
   rcl_timer_t timer1;
   const unsigned int timer1_timeout = 100;
   rcl_clock_t clock;
@@ -422,21 +406,18 @@ public:
   void SetUp()
   {
     rcl_ret_t ret;
+    rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
+    ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    // TODO(jan) hmm das kann weg, oder?
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
+    });
+    // sollte normales objekt sein
+    this->context = rcl_get_zero_initialized_context();
+    ret = rcl_init(0, nullptr, &init_options, &this->context);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
-    // TODO(jan) hmm why these braces? funktioniert auch ohne?
-    {
-      rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
-      ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
-      ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      // TODO(jan) hmm das kann weg, oder?
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-        EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
-      });
-      // sollte normales objekt sein
-      this->context = rcl_get_zero_initialized_context();
-      ret = rcl_init(0, nullptr, &init_options, &this->context);
-      ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    }
     // create ROS node
     this->node = rcl_get_zero_initialized_node();
     const char * name = "executor_test";
@@ -446,73 +427,17 @@ public:
     const rcl_node_options_t * node_ops = rcl_node_get_options(&this->node);
     this->allocator_ptr = &node_ops->allocator;
 
-    // TODO(jan)
-    // macro erstellen: create publisher 1 - cmd_vel
-    // parameter:
-    // - topic_name "cmd_vel"
-    // - type_support geometry_msgs msg Twist => change to std_msgs int
-    // - this->pub1_topic_name
-    // - this->pub1_ptr
-    // - this->node_ptr
-    // - this->pub1_type_support
-    // - this->pub1_options
+    // create publishers - correspond to member variables pub1, pub2, pub3
+    // topic name can be configured (should only match with subscription configuration)
+    CREATE_PUBLISHER(pub1, data1_int)
+    CREATE_PUBLISHER(pub2, data2_int)
+    CREATE_PUBLISHER(pub3, data3_int)
 
-    // create integer publisher
-    this->pub1_int_topic_name = "data1_int";
-    this->pub1_int = rcl_get_zero_initialized_publisher();
-    this->pub1_int_type_support =
-      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32);
-    this->pub1_int_options = rcl_publisher_get_default_options();
-    ret = rcl_publisher_init(&this->pub1_int, &this->node, this->pub1_int_type_support,
-        this->pub1_int_topic_name, &this->pub1_int_options);
-    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
-    this->pub2_int_topic_name = "data2_int";
-    this->pub2_int = rcl_get_zero_initialized_publisher();
-    this->pub2_int_type_support =
-      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32);
-    this->pub2_int_options = rcl_publisher_get_default_options();
-    ret = rcl_publisher_init(&this->pub2_int, &this->node, this->pub2_int_type_support,
-        this->pub2_int_topic_name, &this->pub2_int_options);
-    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
-    this->pub3_int_topic_name = "data3_int";
-    this->pub3_int = rcl_get_zero_initialized_publisher();
-    this->pub3_int_type_support =
-      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32);
-    this->pub3_int_options = rcl_publisher_get_default_options();
-    ret = rcl_publisher_init(&this->pub3_int, &this->node, this->pub3_int_type_support,
-        this->pub3_int_topic_name, &this->pub3_int_options);
-    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
-
-    // create integer subscription 1 - listens to publisher pub1_int
-    this->sub1_int = rcl_get_zero_initialized_subscription();
-    this->sub1_int_options = rcl_subscription_get_default_options();
-    ret = rcl_subscription_init(&this->sub1_int, &this->node, this->pub1_int_type_support,
-        this->pub1_int_topic_name, &this->sub1_int_options);
-    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    EXPECT_TRUE(rcl_subscription_is_valid(&this->sub1_int));
-    rcl_reset_error();
-
-
-    // create integer subscription 2 - listens to publisher pub2_int
-    this->sub2_int = rcl_get_zero_initialized_subscription();
-    this->sub2_int_options = rcl_subscription_get_default_options();
-    ret = rcl_subscription_init(&this->sub2_int, &this->node, this->pub2_int_type_support,
-        this->pub2_int_topic_name, &this->sub2_int_options);
-    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    EXPECT_TRUE(rcl_subscription_is_valid(&this->sub2_int));
-    rcl_reset_error();
-
-    // create integer subscription 3 - listens to publisher pub3_int
-    this->sub3_int = rcl_get_zero_initialized_subscription();
-    this->sub3_int_options = rcl_subscription_get_default_options();
-    ret = rcl_subscription_init(&this->sub3_int, &this->node, this->pub3_int_type_support,
-        this->pub3_int_topic_name, &this->sub3_int_options);
-    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    EXPECT_TRUE(rcl_subscription_is_valid(&this->sub3_int));
-    rcl_reset_error();
+    // create subscriptions - correspond to member variables sub1, sub2, sub3
+    // topic name of subscriber i (subi) must be the same as publisher i (pubi)
+    CREATE_SUBSCRIPTION(sub1, data1_int)
+    CREATE_SUBSCRIPTION(sub2, data2_int)
+    CREATE_SUBSCRIPTION(sub3, data3_int)
 
     // create timer with rcl
     this->clock_allocator = rcl_get_default_allocator();
@@ -528,11 +453,11 @@ public:
   void TearDown()
   {
     rcl_ret_t ret;
-    ret = rcl_subscription_fini(&this->sub1_int, &this->node);
+    ret = rcl_subscription_fini(&this->sub1, &this->node);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    ret = rcl_subscription_fini(&this->sub2_int, &this->node);
+    ret = rcl_subscription_fini(&this->sub2, &this->node);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    ret = rcl_subscription_fini(&this->sub3_int, &this->node);
+    ret = rcl_subscription_fini(&this->sub3, &this->node);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_timer_fini(&this->timer1);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
@@ -546,7 +471,6 @@ public:
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 };
-
 
 /*
  * Test suite
@@ -588,7 +512,7 @@ TEST_F(TestDefaultExecutor, executor_fini) {
   rclc_executor_t executor;
 
   executor = rclc_executor_get_zero_initialized_executor();
-  rc = rclc_executor_init(&executor, this->context_ptr, 10, this->allocator_ptr);
+  rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
   // normal case
@@ -601,18 +525,17 @@ TEST_F(TestDefaultExecutor, executor_fini) {
   rcutils_reset_error();
 }
 
-/*
 TEST_F(TestDefaultExecutor, executor_add_subscription) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   executor = rclc_executor_get_zero_initialized_executor();
   // test with normal arguemnt and NULL pointers as arguments
-  rc = rclc_executor_init(&executor, this->context_ptr, 10, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
   // normal case
-  rc = rclc_executor_add_subscription(&executor, this->sub1_ptr, &this->sub1_msg,
-      &cmd_vel_callback, ON_NEW_DATA);
+  rc = rclc_executor_add_subscription(&executor, &this->sub1, &this->sub1_msg,
+      &INT_CALLBACK(1), ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
   size_t num_subscriptions = 1;
@@ -620,7 +543,7 @@ TEST_F(TestDefaultExecutor, executor_add_subscription) {
     "number of subscriptions is expected to be one";
 
   // test NULL pointer for executor
-  rc = rclc_executor_add_subscription(NULL, this->sub1_ptr, &this->sub1_msg, &cmd_vel_callback,
+  rc = rclc_executor_add_subscription(NULL, &this->sub1, &this->sub1_msg, &INT_CALLBACK(1),
       ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -628,7 +551,7 @@ TEST_F(TestDefaultExecutor, executor_add_subscription) {
     "number of subscriptions is expected to be one";
 
   // test NULL pointer for subscription
-  rc = rclc_executor_add_subscription(&executor, NULL, &this->sub1_msg, &cmd_vel_callback,
+  rc = rclc_executor_add_subscription(&executor, NULL, &this->sub1_msg, &INT_CALLBACK(1),
       ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -636,7 +559,7 @@ TEST_F(TestDefaultExecutor, executor_add_subscription) {
     "number of subscriptions is expected to be one";
 
   // test NULL pointer for message
-  rc = rclc_executor_add_subscription(&executor, this->sub1_ptr, NULL, &cmd_vel_callback,
+  rc = rclc_executor_add_subscription(&executor, &this->sub1, NULL, &INT_CALLBACK(1),
       ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -644,7 +567,7 @@ TEST_F(TestDefaultExecutor, executor_add_subscription) {
     "number of subscriptions is expected to be one";
 
   // test NULL pointer for callback
-  rc = rclc_executor_add_subscription(&executor, this->sub1_ptr, &this->sub1_msg, NULL,
+  rc = rclc_executor_add_subscription(&executor, &this->sub1, &this->sub1_msg, NULL,
       ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -655,14 +578,14 @@ TEST_F(TestDefaultExecutor, executor_add_subscription) {
   rc = rclc_executor_fini(&executor);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
-
+/*
 TEST_F(TestDefaultExecutor, executor_add_subscription_too_many) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   executor = rclc_executor_get_zero_initialized_executor();
   // insert one handle, add two subscriptions
 
-  rc = rclc_executor_init(&executor, this->context_ptr, 1, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 1, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
   // test 1: add subscription
@@ -691,7 +614,7 @@ TEST_F(TestDefaultExecutor, executor_add_timer) {
   rclc_executor_t executor;
   executor = rclc_executor_get_zero_initialized_executor();
   // add a timer
-  rc = rclc_executor_init(&executor, this->context_ptr, 10, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 10, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
   size_t exp_number_of_timers = 0;
@@ -711,7 +634,7 @@ TEST_F(TestDefaultExecutor, executor_spin_some_API) {
   rclc_executor_t executor;
   executor = rclc_executor_get_zero_initialized_executor();
   // add a timer
-  rc = rclc_executor_init(&executor, this->context_ptr, 10, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 10, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
   rc = rclc_executor_add_timer(&executor, this->timer1_ptr);
@@ -811,7 +734,7 @@ TEST_F(TestDefaultExecutor, pub_sub_example) {
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
   bool success;
-  wait_for_subscription_to_be_ready(&subscription, this->context_ptr, 10, 100, success);
+  wait_for_subscription_to_be_ready(&subscription, &this->context, 10, 100, success);
   ASSERT_TRUE(success);
   {
     std_msgs__msg__Int32 msg;
@@ -920,7 +843,7 @@ TEST_F(TestDefaultExecutor, spin_some_let_semantic) {
   // initialize result variables
   _executor_results_init();
   // initialize executor with 3 handles
-  ret = rclc_executor_init(&executor, this->context_ptr, 3, this->allocator);
+  ret = rclc_executor_init(&executor, &this->context, 3, this->allocator);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   // define subscription messages
@@ -1156,7 +1079,7 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   // initialize result variables
   _executor_results_init();
   // initialize executor with 2 handles
-  ret = rclc_executor_init(&executor, this->context_ptr, 2, this->allocator);
+  ret = rclc_executor_init(&executor, &this->context, 2, this->allocator);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   ret = rclc_executor_set_trigger(&executor, rclc_executor_trigger_always, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
@@ -1279,7 +1202,7 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   // initialize result variables
   _results_callback_counters_init();
   // initialize executor with 2 handles
-  ret = rclc_executor_init(&executor, this->context_ptr, 2, this->allocator);
+  ret = rclc_executor_init(&executor, &this->context, 2, this->allocator);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   // define subscription messages
@@ -1378,7 +1301,7 @@ TEST_F(TestDefaultExecutor, spin_period) {
   rclc_executor_t executor;
 
   // initialize executor with 1 handle
-  rc = rclc_executor_init(&executor, this->context_ptr, 1, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 1, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
   // set timeout to zero - so that rcl_wait() comes back immediately
@@ -1435,26 +1358,26 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
   //   => subscriber B receives X=1 (because data is taken from DDS at the start of spin_some() )
 
   // implementation
-  // use member variable this->pub1_int as publisher
-  // use member variable this->sub1_int as subscription 1
+  // use member variable this->pub1 as publisher
+  // use member variable this->sub1 as subscription 1
   // create subscription 2 with last-is-best semantics
   rcl_subscription_t subscription2 = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t subscription_options2 = rcl_subscription_get_default_options();
   std_msgs__msg__Int32 subscription2_int_msg;
   subscription_options2.qos.depth = 0;  // qos: last is best
-  rc = rcl_subscription_init(&subscription2, this->node_ptr, this->pub1_int_type_support,
-      this->pub1_int_topic_name, &subscription_options2);
+  rc = rcl_subscription_init(&subscription2, this->node_ptr, this->pub1_type_support,
+      this->pub1_topic_name, &subscription_options2);
   ASSERT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   EXPECT_TRUE(rcl_subscription_is_valid(&subscription2));
   rcl_reset_error();
 
   // initialize executor with 2 handles
-  rc = rclc_executor_init(&executor, this->context_ptr, 2, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 2, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // add subscriptions to executor
-  rc = rclc_executor_add_subscription(&executor, &this->sub1_int, &this->sub1_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub1, &this->sub1_msg,
       &int32_callback4, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1465,15 +1388,15 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
 
   // create global pointer to this publisher to access it from callback 'int32_callback4'
   // of the subscriber 'this->sub_int'
-  _pub_int_ptr = &this->pub1_int;
-  _pub_int_msg_ptr = &this->pub1_int_msg;
+  _pub_int_ptr = &this->pub1;
+  _pub_int_msg_ptr = &this->pub1_msg;
 
   // ------------------------- test case setup ------------------------
   rclc_executor_set_semantics(&executor, RCLCPP_EXECUTOR);
-  this->pub1_int_msg.data = 1;
+  this->pub1_msg.data = 1;
   _cb5_int_value = 0;  // received value in subscription2
-  rc = rcl_publish(&this->pub1_int, &this->pub1_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub1_int(tc) did not publish!";
+  rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub1(tc) did not publish!";
 
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   const uint64_t timeout_ns = 10000000;  // 10ms
@@ -1520,26 +1443,26 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
   //   => subscriber B receives X=1 (because data is taken from DDS at the start of spin_some() )
 
   // implementation
-  // use member variable this->pub1_int as publisher
-  // use member variable this->sub1_int as subscription 1
+  // use member variable this->pub1 as publisher
+  // use member variable this->sub1 as subscription 1
   // create subscription 2 with last-is-best semantics
   rcl_subscription_t subscription2 = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t subscription_options2 = rcl_subscription_get_default_options();
   std_msgs__msg__Int32 subscription2_int_msg;
   subscription_options2.qos.depth = 0;  // qos: last is best
-  rc = rcl_subscription_init(&subscription2, this->node_ptr, this->pub1_int_type_support,
-      this->pub1_int_topic_name, &subscription_options2);
+  rc = rcl_subscription_init(&subscription2, this->node_ptr, this->pub1_type_support,
+      this->pub1_topic_name, &subscription_options2);
   ASSERT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   EXPECT_TRUE(rcl_subscription_is_valid(&subscription2));
   rcl_reset_error();
 
   // initialize executor with 2 handles
-  rc = rclc_executor_init(&executor, this->context_ptr, 2, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 2, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // add subscriptions to executor
-  rc = rclc_executor_add_subscription(&executor, &this->sub1_int, &this->sub1_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub1, &this->sub1_msg,
       &int32_callback4, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1550,15 +1473,15 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
 
   // create global pointer to this publisher to access it from callback 'int32_callback4'
   // of the subscriber 'this->sub_int'
-  _pub_int_ptr = &this->pub1_int;
-  _pub_int_msg_ptr = &this->pub1_int_msg;
+  _pub_int_ptr = &this->pub1;
+  _pub_int_msg_ptr = &this->pub1_msg;
 
   // ------------------------- test case setup ------------------------
   rclc_executor_set_semantics(&executor, LET);
-  this->pub1_int_msg.data = 1;
+  this->pub1_msg.data = 1;
   _cb5_int_value = 0;  // received value in subscription2
-  rc = rcl_publish(&this->pub1_int, &this->pub1_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub1_int(tc) did not publish!";
+  rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub1(tc) did not publish!";
 
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   const uint64_t timeout_ns = 10000000;  // 10ms
@@ -1566,7 +1489,7 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
   // test result
   EXPECT_EQ(_cb5_int_value,
     (unsigned int) 1) <<
-    " expect value 1: first value of 'pub1_int' publisher should have been received.";
+    " expect value 1: first value of 'pub1' publisher should have been received.";
 
   // clean-up
   rc = rcl_subscription_fini(&subscription2, this->node_ptr);
@@ -1603,17 +1526,17 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   // initialize executor with 2 handles
-  rc = rclc_executor_init(&executor, this->context_ptr, 2, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 2, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
-  rc = rclc_executor_set_trigger(&executor, rclc_executor_trigger_one, &this->sub1_int);
+  rc = rclc_executor_set_trigger(&executor, rclc_executor_trigger_one, &this->sub1);
 
   // add subscriptions to executor
-  rc = rclc_executor_add_subscription(&executor, &this->sub1_int, &this->sub1_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub1, &this->sub1_msg,
       &int32_callback6, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  rc = rclc_executor_add_subscription(&executor, &this->sub2_int, &this->sub2_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub2, &this->sub2_msg,
       &int32_callback7, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1622,9 +1545,9 @@ TEST_F(TestDefaultExecutor, trigger_one) {
 
   // first round
   _reset_result_values_for_trigger_test_case();
-  this->pub1_int_msg.data = 3;
-  rc = rcl_publish(&this->pub1_int, &this->pub1_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub1_int did not publish!";
+  this->pub1_msg.data = 3;
+  rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 3) << " expected: A called";
@@ -1632,9 +1555,9 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   EXPECT_EQ(_cb6_cnt, (unsigned int) 1);
   EXPECT_EQ(_cb7_cnt, (unsigned int) 0);
   // second round
-  this->pub2_int_msg.data = 7;
-  rc = rcl_publish(&this->pub2_int, &this->pub2_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub2_int did not publish!";
+  this->pub2_msg.data = 7;
+  rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 3) << " expected: A not called";
@@ -1643,9 +1566,9 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   EXPECT_EQ(_cb7_cnt, (unsigned int) 0);
 
   // third round
-  this->pub1_int_msg.data = 11;
-  rc = rcl_publish(&this->pub1_int, &this->pub1_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub1_int did not publish!";
+  this->pub1_msg.data = 11;
+  rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 11) << " expected: A called";
@@ -1679,17 +1602,17 @@ TEST_F(TestDefaultExecutor, trigger_any) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   // initialize executor with 2 handles
-  rc = rclc_executor_init(&executor, this->context_ptr, 2, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 2, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
   rc = rclc_executor_set_trigger(&executor, rclc_executor_trigger_any, NULL);
 
   // add subscriptions to executor
-  rc = rclc_executor_add_subscription(&executor, &this->sub1_int, &this->sub1_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub1, &this->sub1_msg,
       &int32_callback6, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  rc = rclc_executor_add_subscription(&executor, &this->sub2_int, &this->sub2_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub2, &this->sub2_msg,
       &int32_callback7, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1698,9 +1621,9 @@ TEST_F(TestDefaultExecutor, trigger_any) {
 
   // first round
   _reset_result_values_for_trigger_test_case();
-  this->pub1_int_msg.data = 3;
-  rc = rcl_publish(&this->pub1_int, &this->pub1_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub1_int did not publish!";
+  this->pub1_msg.data = 3;
+  rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 3) << " expected: A called";
@@ -1708,9 +1631,9 @@ TEST_F(TestDefaultExecutor, trigger_any) {
   EXPECT_EQ(_cb6_cnt, (unsigned int) 1);
   EXPECT_EQ(_cb7_cnt, (unsigned int) 0);
   // second round
-  this->pub2_int_msg.data = 7;
-  rc = rcl_publish(&this->pub2_int, &this->pub2_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub2_int did not publish!";
+  this->pub2_msg.data = 7;
+  rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 3) << " expected: A not called";
@@ -1719,11 +1642,11 @@ TEST_F(TestDefaultExecutor, trigger_any) {
   EXPECT_EQ(_cb7_cnt, (unsigned int) 1);
 
   // third round
-  this->pub1_int_msg.data = 11;
+  this->pub1_msg.data = 11;
   _cb6_int_value = 0;
   _cb7_int_value = 0;
-  rc = rcl_publish(&this->pub1_int, &this->pub1_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub1_int did not publish!";
+  rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 11) << " expected: A called";
@@ -1757,17 +1680,17 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   // initialize executor with 2 handles
-  rc = rclc_executor_init(&executor, this->context_ptr, 2, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 2, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
   rc = rclc_executor_set_trigger(&executor, rclc_executor_trigger_all, NULL);
 
   // add subscriptions to executor
-  rc = rclc_executor_add_subscription(&executor, &this->sub1_int, &this->sub1_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub1, &this->sub1_msg,
       &int32_callback6, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  rc = rclc_executor_add_subscription(&executor, &this->sub2_int, &this->sub2_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub2, &this->sub2_msg,
       &int32_callback7, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1776,9 +1699,9 @@ TEST_F(TestDefaultExecutor, trigger_all) {
 
   // first round
   _reset_result_values_for_trigger_test_case();
-  this->pub1_int_msg.data = 3;
-  rc = rcl_publish(&this->pub1_int, &this->pub1_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub1_int did not publish!";
+  this->pub1_msg.data = 3;
+  rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 0) << " expected: A not called";
@@ -1786,9 +1709,9 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   EXPECT_EQ(_cb6_cnt, (unsigned int) 0);
   EXPECT_EQ(_cb7_cnt, (unsigned int) 0);
   // second round
-  this->pub2_int_msg.data = 7;
-  rc = rcl_publish(&this->pub2_int, &this->pub2_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub2_int did not publish!";
+  this->pub2_msg.data = 7;
+  rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 3) << " expected: A called";
@@ -1797,11 +1720,11 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   EXPECT_EQ(_cb7_cnt, (unsigned int) 1);
 
   // third round
-  this->pub1_int_msg.data = 11;
+  this->pub1_msg.data = 11;
   _cb6_int_value = 0;
   _cb7_int_value = 0;
-  rc = rcl_publish(&this->pub1_int, &this->pub1_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub1_int did not publish!";
+  rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 0) << " expected: A not called";
@@ -1831,17 +1754,17 @@ TEST_F(TestDefaultExecutor, trigger_always) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   // initialize executor with 2 handles
-  rc = rclc_executor_init(&executor, this->context_ptr, 2, this->allocator);
+  rc = rclc_executor_init(&executor, &this->context, 2, this->allocator);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
   rc = rclc_executor_set_trigger(&executor, rclc_executor_trigger_always, NULL);
 
   // add subscriptions to executor
-  rc = rclc_executor_add_subscription(&executor, &this->sub1_int, &this->sub1_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub1, &this->sub1_msg,
       &int32_callback6, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  rc = rclc_executor_add_subscription(&executor, &this->sub2_int, &this->sub2_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub2, &this->sub2_msg,
       &int32_callback7, ALWAYS);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1856,9 +1779,9 @@ TEST_F(TestDefaultExecutor, trigger_always) {
   EXPECT_EQ(_cb6_cnt, (unsigned int) 0) << " expected: A not called";
   EXPECT_EQ(_cb7_cnt, (unsigned int) 1) << " expected: B called";
   // second round
-  this->pub1_int_msg.data = 3;
-  rc = rcl_publish(&this->pub1_int, &this->pub1_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub1_int did not publish!";
+  this->pub1_msg.data = 3;
+  rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 3) << " expected: A called";
@@ -1866,11 +1789,11 @@ TEST_F(TestDefaultExecutor, trigger_always) {
   EXPECT_EQ(_cb6_cnt, (unsigned int) 1) << " expected: A called";
   EXPECT_EQ(_cb7_cnt, (unsigned int) 2) << " expected: B called";
   // third round
-  this->pub2_int_msg.data = 7;
+  this->pub2_msg.data = 7;
   _cb6_int_value = 0;
   _cb7_int_value = 0;
-  rc = rcl_publish(&this->pub2_int, &this->pub2_int_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub2_int did not publish!";
+  rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclc_executor_spin_some(&executor, timeout_ns);
   EXPECT_EQ(_cb6_int_value, (unsigned int) 0) << " expected: A not called";

--- a/rclc/test/test_executor.cpp
+++ b/rclc/test/test_executor.cpp
@@ -191,7 +191,7 @@ _executor_results_compare(unsigned int * array)
   { \
     const std_msgs__msg__Int32 * msg = (const std_msgs__msg__Int32 *)msgin; \
     if (msg == NULL) { \
-      printf("Test CB " #NUM ": msg is NULL\n"); \
+      // printf("Test CB " #NUM ": msg is NULL\n"); \
     } else { \
       _cb ## NUM ## _int_value = msg->data; \
     } \
@@ -391,7 +391,6 @@ wait_for_subscription_to_be_ready(
       }
     }
   } while ( (*tries) < max_tries);
-
 }
 
 class TestDefaultExecutor : public ::testing::Test
@@ -487,8 +486,8 @@ public:
     CREATE_SUBSCRIPTION(sub1, data1_int)
     CREATE_SUBSCRIPTION(sub2, data2_int)
     CREATE_SUBSCRIPTION(sub3, data3_int)
-    std_msgs__msg__Int32__init(&sub1_msg);
-    std_msgs__msg__Int32__init(&sub2_msg);
+    std_msgs__msg__Int32__init(&this->sub1_msg);
+    std_msgs__msg__Int32__init(&this->sub2_msg);
     std_msgs__msg__Int32__init(&sub3_msg);
 
     // create timer with rcl
@@ -726,7 +725,7 @@ TEST_F(TestDefaultExecutor, pub_sub_example) {
   unsigned int timeout_ms = 10;
   wait_for_subscription_to_be_ready(&this->sub1, &this->context, max_tries, timeout_ms, &tries,
     &success);
-  //printf("Number of tries to access DDS-queue: %u\n", tries);
+  // printf("Number of tries to access DDS-queue: %u\n", tries);
   ASSERT_TRUE(success);
 
   ret = rcl_take(&this->sub1, &this->sub1_msg, nullptr, nullptr);
@@ -806,7 +805,7 @@ TEST_F(TestDefaultExecutor, spin_some_sequential_execution) {
   // printf("Number of tries to access DDS-queue: %u\n", tries);
   ASSERT_TRUE(success);
 
-  // process subscriptions in Executor. Assumption: messages for all sub1, sub2 and sub3 are available
+  // process subscriptions. Assumption: messages for all sub1, sub2 and sub3 are available
   for (unsigned int i = 0; i < 100; i++) {
     const unsigned int timeout_ms = 100;
     ret = rclc_executor_spin_some(&executor, timeout_ms);
@@ -859,7 +858,7 @@ TEST_F(TestDefaultExecutor, spin_some_sequential_execution) {
   // printf("Number of tries to access DDS-queue: %u\n", tries);
   ASSERT_TRUE(success);
 
-  // process subscriptions in Executor. Assumption: messages for all sub1, sub2 and sub3 are available
+  // process subscriptions. Assumption: messages for all sub1, sub2 and sub3 are available
   for (unsigned int i = 0; i < 100; i++) {
     const unsigned int timeout_ms = 100;
     ret = rclc_executor_spin_some(&executor, timeout_ms);
@@ -888,7 +887,7 @@ TEST_F(TestDefaultExecutor, spin_some_sequential_execution) {
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcutils_reset_error();
 }
-/*
+
 TEST_F(TestDefaultExecutor, invocation_type) {
   // 27.06.2019, adopted from ros2/rcl/rcl/test/rcl/test_subscriptions.cpp
   // by Jan Staschulat, under Apache 2.0 License
@@ -916,55 +915,6 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   rcl_ret_t ret;
   rclc_executor_t executor;
   executor = rclc_executor_get_zero_initialized_executor();
-  // publisher 1
-  rcl_publisher_t publisher1 = rcl_get_zero_initialized_publisher();
-  const rosidl_message_type_support_t * ts1 =
-    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32);
-  const char * topic1 = "chatter1";
-  rcl_publisher_options_t publisher_options1 = rcl_publisher_get_default_options();
-  ret = rcl_publisher_init(&this->pub1, this->node_ptr, ts1, topic1, &publisher_options1);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_publisher_fini(&this->pub1, this->node_ptr);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  });
-
-  // publisher 2
-  rcl_publisher_t this->pub2 = rcl_get_zero_initialized_publisher();
-  const rosidl_message_type_support_t * ts2 =
-    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32);
-  const char * topic2 = "chatter2";
-  rcl_publisher_options_t publisher_options2 = rcl_publisher_get_default_options();
-  ret = rcl_publisher_init(&this->pub2, this->node_ptr, ts2, topic2, &publisher_options2);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_publisher_fini(&this->pub2, this->node_ptr);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  });
-
-  // subscription 1
-  rcl_subscription_t subscription1 = rcl_get_zero_initialized_subscription();
-  rcl_subscription_options_t subscription_options1 = rcl_subscription_get_default_options();
-  ret = rcl_subscription_init(&subscription1, this->node_ptr, ts1, topic1, &subscription_options1);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_subscription_fini(&subscription1, this->node_ptr);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  });
-  EXPECT_TRUE(rcl_subscription_is_valid(&subscription1));
-  rcl_reset_error();
-
-  // subscription 2
-  rcl_subscription_t subscription2 = rcl_get_zero_initialized_subscription();
-  rcl_subscription_options_t subscription_options2 = rcl_subscription_get_default_options();
-  ret = rcl_subscription_init(&subscription2, this->node_ptr, ts2, topic2, &subscription_options2);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_subscription_fini(&subscription2, this->node_ptr);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  });
-  EXPECT_TRUE(rcl_subscription_is_valid(&subscription2));
-  rcl_reset_error();
 
   // initialize result variables
   _executor_results_init();
@@ -974,22 +924,15 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   ret = rclc_executor_set_trigger(&executor, rclc_executor_trigger_always, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
-  // define subscription messages
-  std_msgs__msg__Int32 sub_msg1;
-  std_msgs__msg__Int32__init(&sub_msg1);
-
-  std_msgs__msg__Int32 sub_msg2;
-  std_msgs__msg__Int32__init(&sub_msg2);
-
   // add subscription to the executor
   ret =
-    rclc_executor_add_subscription(&executor, &subscription1, &sub_msg1, &int32_callback1,
+    rclc_executor_add_subscription(&executor, &this->sub1, &this->sub1_msg, &CALLBACK_1,
       ALWAYS);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcutils_reset_error();
 
   ret =
-    rclc_executor_add_subscription(&executor, &subscription2, &sub_msg2, &int32_callback2,
+    rclc_executor_add_subscription(&executor, &this->sub2, &this->sub2_msg, &CALLBACK_2,
       ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -999,28 +942,26 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
     "number of subscriptions should be = 2";
 
-  // publish message 1
-  std_msgs__msg__Int32 pub_msg1;
-  std_msgs__msg__Int32__init(&pub_msg1);
-  pub_msg1.data = 1;
-
-  // publish message 2
-  std_msgs__msg__Int32 pub_msg2;
-  std_msgs__msg__Int32__init(&this->pub2_msg);
-  pub_msg2.data = 2;
-
-
   ///////////////////////////////////////////////////////////////////////////////////
   /////////// test case 1 : publish one data for each publisher
   ///////////////////////////////////////////////////////////////////////////////////
-
-
-  ret = rcl_publish(&this->pub1, &pub_msg1, nullptr);
-  EXPECT_EQ(RCL_RET_OK, ret) << " publisher1 did not publish!";
+  ret = rcl_publish(&this->pub1, &pub1_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << " this->pub1 did not publish!";
   ret = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, ret) << " this->pub2 did not publish!";
-  // give DDS some time to publish the message (without the test fails)
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // wait until messages are received
+  bool success = false;
+  unsigned int tries;
+  unsigned int max_tries = 100;
+  unsigned int timeout_ms = 10;
+  wait_for_subscription_to_be_ready(&this->sub1, &this->context, max_tries, timeout_ms, &tries,
+    &success);
+  ASSERT_TRUE(success);
+  wait_for_subscription_to_be_ready(&this->sub2, &this->context, max_tries, timeout_ms, &tries,
+    &success);
+  ASSERT_TRUE(success);
+
   // initialize result variables
   _cb1_cnt = 0;
   _cb2_cnt = 0;
@@ -1042,7 +983,7 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   EXPECT_EQ(_cb2_cnt, (unsigned int) 1) << "cb2 msg does not match";
 }
 
-
+/*
 // call executor_add_subscription() after executor_spin_some()
 // this requires an update of the rcl wait_set
 TEST_F(TestDefaultExecutor, update_wait_set) {
@@ -1068,25 +1009,25 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   // subscription 1
   rcl_subscription_t subscription1 = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t subscription_options1 = rcl_subscription_get_default_options();
-  ret = rcl_subscription_init(&subscription1, this->node_ptr, ts1, topic1, &subscription_options1);
+  ret = rcl_subscription_init(&this->sub1, this->node_ptr, ts1, topic1, &subscription_options1);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_subscription_fini(&subscription1, this->node_ptr);
+    rcl_ret_t ret = rcl_subscription_fini(&this->sub1, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
-  EXPECT_TRUE(rcl_subscription_is_valid(&subscription1));
+  EXPECT_TRUE(rcl_subscription_is_valid(&this->sub1));
   rcl_reset_error();
 
   // subscription 2
   rcl_subscription_t subscription2 = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t subscription_options2 = rcl_subscription_get_default_options();
-  ret = rcl_subscription_init(&subscription2, this->node_ptr, ts1, topic1, &subscription_options2);
+  ret = rcl_subscription_init(&this->sub2, this->node_ptr, ts1, topic1, &subscription_options2);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_subscription_fini(&subscription2, this->node_ptr);
+    rcl_ret_t ret = rcl_subscription_fini(&this->sub2, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
-  EXPECT_TRUE(rcl_subscription_is_valid(&subscription2));
+  EXPECT_TRUE(rcl_subscription_is_valid(&this->sub2));
   rcl_reset_error();
 
   // initialize result variables
@@ -1097,16 +1038,16 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
 
   // define subscription messages
   std_msgs__msg__Int32 sub_msg1;
-  std_msgs__msg__Int32__init(&sub_msg1);
+  std_msgs__msg__Int32__init(&this->sub2_msg);
 
   std_msgs__msg__Int32 sub_msg2;
-  std_msgs__msg__Int32__init(&sub_msg2);
+  std_msgs__msg__Int32__init(&this->sub2_msg);
 
   // initially the wait_set is zero_initialized
   EXPECT_EQ(false, rcl_wait_set_is_valid(&executor.wait_set));
   // add subscription to the executor
   ret =
-    rclc_executor_add_subscription(&executor, &subscription1, &sub_msg1, &int32_callback1,
+    rclc_executor_add_subscription(&executor, &this->sub1, &this->sub2_msg, &CALLBACK_1,
       ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1116,7 +1057,7 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
 
   // initialize pub message 1
   std_msgs__msg__Int32 pub_msg1;
-  std_msgs__msg__Int32__init(&pub_msg1);
+  std_msgs__msg__Int32__init(&pub1_msg);
   pub_msg1.data = 1;
 
   ///////////////////////////////////////////////////////////////////////////////////
@@ -1127,9 +1068,9 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   EXPECT_EQ((unsigned int)0, _cb1_cnt);
   EXPECT_EQ((unsigned int)0, _cb2_cnt);
 
-  ret = rcl_publish(&this->pub1, &pub_msg1, nullptr);
+  ret = rcl_publish(&this->pub1, &pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, ret) << " publisher1 did not publish!";
-  ret = rcl_publish(&this->pub1, &pub_msg1, nullptr);
+  ret = rcl_publish(&this->pub1, &pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, ret) << " publisher1 did not publish!";
 
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));
@@ -1157,7 +1098,7 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   EXPECT_EQ(true, rcl_wait_set_is_valid(&executor.wait_set));
 
   ret =
-    rclc_executor_add_subscription(&executor, &subscription2, &sub_msg2, &int32_callback2,
+    rclc_executor_add_subscription(&executor, &this->sub2, &this->sub2_msg, &CALLBACK_2,
       ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1255,10 +1196,10 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
   rcl_subscription_options_t subscription_options2 = rcl_subscription_get_default_options();
   std_msgs__msg__Int32 subscription2_int_msg;
   subscription_options2.qos.depth = 0;  // qos: last is best
-  rc = rcl_subscription_init(&subscription2, this->node_ptr, this->pub1_type_support,
+  rc = rcl_subscription_init(&this->sub2, this->node_ptr, this->pub1_type_support,
       this->pub1_topic_name, &subscription_options2);
   ASSERT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_TRUE(rcl_subscription_is_valid(&subscription2));
+  EXPECT_TRUE(rcl_subscription_is_valid(&this->sub2));
   rcl_reset_error();
 
   // initialize executor with 2 handles
@@ -1271,7 +1212,7 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
       &int32_callback4, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  rc = rclc_executor_add_subscription(&executor, &subscription2, &subscription2_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub2, &this->sub2_int_msg,
       &int32_callback5, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1297,7 +1238,7 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
     " expect value 2: Value from callback of int32_callback4 should be received.";
 
   // clean-up
-  rc = rcl_subscription_fini(&subscription2, this->node_ptr);
+  rc = rcl_subscription_fini(&this->sub2, this->node_ptr);
 }
 
 
@@ -1340,10 +1281,10 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
   rcl_subscription_options_t subscription_options2 = rcl_subscription_get_default_options();
   std_msgs__msg__Int32 subscription2_int_msg;
   subscription_options2.qos.depth = 0;  // qos: last is best
-  rc = rcl_subscription_init(&subscription2, this->node_ptr, this->pub1_type_support,
+  rc = rcl_subscription_init(&this->sub2, this->node_ptr, this->pub1_type_support,
       this->pub1_topic_name, &subscription_options2);
   ASSERT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_TRUE(rcl_subscription_is_valid(&subscription2));
+  EXPECT_TRUE(rcl_subscription_is_valid(&this->sub2));
   rcl_reset_error();
 
   // initialize executor with 2 handles
@@ -1356,7 +1297,7 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
       &int32_callback4, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  rc = rclc_executor_add_subscription(&executor, &subscription2, &subscription2_int_msg,
+  rc = rclc_executor_add_subscription(&executor, &this->sub2, &this->sub2_int_msg,
       &int32_callback5, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
@@ -1382,7 +1323,7 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
     " expect value 1: first value of 'pub1' publisher should have been received.";
 
   // clean-up
-  rc = rcl_subscription_fini(&subscription2, this->node_ptr);
+  rc = rcl_subscription_fini(&this->sub2, this->node_ptr);
 }
 
 


### PR DESCRIPTION
Refactored unit tests for RCLC-Executor
- used macros to define callbacks
- used macros to create publisher, subscriber
- used class members for publisher, subscriber instead of defining them in the test cases (=> sharing code)
- replaced "new" for dynamic memory allocation by defining the objects themselves
- replaced message data types 'geometry__msgs__Twist' and 'std__msgs__String' with 'std__msgs__Int32' for simplicity, removed package 'geometry_msgs' from build config
- reduced number of callbacks for all test cases (5 callbacks instead of 8)
- replaced fixed waiting time for DDS to publish messages by a function, which polls wait_set with a small timeout until the message has been communicated. 

Result: 
- Reduced lines of code by 20% (from 1905 => 1520 LoC)
- Reduced execution time of unit tests by 50% ( from 14s => 6,5s)
