### PR TITLE
Added init with options

### DIFF
--- a/rclc/README.md
+++ b/rclc/README.md
@@ -530,6 +530,7 @@ The rclc package also provides a number of convenience functions, which make it 
 
 Convenience functions:
 - rclc_support_init()
+- rclc_support_init_with_options()
 - rclc_support_fini()
 - rclc_node_init_default()
 - rclc_publisher_init_default()

--- a/rclc/include/rclc/init.h
+++ b/rclc/include/rclc/init.h
@@ -51,6 +51,34 @@ rclc_support_init(
   char const * const * argv,
   rcl_allocator_t * allocator);
 
+/**
+ *  Initializes rcl and creates some support data structures.
+ *  Initializes clock as RCL_STEADY_TIME.
+ *  * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes (in RCL)
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[inout] support a zero-initialized rclc_support_t
+ * \param[in] argc number of args of main
+ * \param[in] argv array of arguments of main
+ * \param[in] init_options custom initial options
+ * \param[in] allocator allocator for allocating memory
+ * \return `RCL_RET_OK` if RCL was initialized successfully
+ * \return `RCL_RET_INVALID_ARGUMENT` if any null pointer as argument
+ * \return `RCL_RET_ERROR` in case of failure
+ */
+rcl_ret_t
+rclc_support_init_with_options(
+  rclc_support_t * support,
+  int argc,
+  char const * const * argv,
+  rcl_init_options_t * init_options,
+  rcl_allocator_t * allocator);
+
 
 /**
  *  De-allocates the rclc_support_t object.

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -58,6 +58,39 @@ rclc_support_init(
 }
 
 rcl_ret_t
+rclc_support_init_with_options(
+  rclc_support_t * support,
+  int argc,
+  char const * const * argv,
+  rcl_init_options_t * init_options,
+  rcl_allocator_t * allocator)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    support, "support is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    init_options, "init_options is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    allocator, "allocator is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t rc = RCL_RET_OK;
+
+  memcpy(&support->init_options, init_options, sizeof(rcl_init_options_t));
+
+  support->context = rcl_get_zero_initialized_context();
+  rc = rcl_init(argc, argv, &support->init_options, &support->context);
+  if (rc != RCL_RET_OK) {
+    PRINT_RCLC_ERROR(rclc_init, rcl_init);
+    return rc;
+  }
+  support->allocator = allocator;
+
+  rc = rcl_clock_init(RCL_STEADY_TIME, &support->clock, support->allocator);
+  if (rc != RCL_RET_OK) {
+    PRINT_RCLC_ERROR(rclc_init, rcl_clock_init);
+  }
+  return rc;
+}
+
+rcl_ret_t
 rclc_support_fini(rclc_support_t * support)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -29,31 +29,17 @@ rclc_support_init(
   char const * const * argv,
   rcl_allocator_t * allocator)
 {
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    support, "support is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator, "allocator is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   rcl_ret_t rc = RCL_RET_OK;
 
-  support->init_options = rcl_get_zero_initialized_init_options();
-  rc = rcl_init_options_init(&support->init_options, (*allocator) );
+  rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
+  rc = rcl_init_options_init(&init_options, (*allocator) );
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_ERROR(rclc_support_init, rcl_init_options_init);
     return rc;
   }
 
-  support->context = rcl_get_zero_initialized_context();
-  rc = rcl_init(argc, argv, &support->init_options, &support->context);
-  if (rc != RCL_RET_OK) {
-    PRINT_RCLC_ERROR(rclc_init, rcl_init);
-    return rc;
-  }
-  support->allocator = allocator;
-
-  rc = rcl_clock_init(RCL_STEADY_TIME, &support->clock, support->allocator);
-  if (rc != RCL_RET_OK) {
-    PRINT_RCLC_ERROR(rclc_init, rcl_clock_init);
-  }
+  rc = rclc_support_init_with_options(support,argc, argv, &init_options, allocator);
+  
   return rc;
 }
 

--- a/rclc/test/rclc/test_init.cpp
+++ b/rclc/test/rclc/test_init.cpp
@@ -60,6 +60,7 @@ TEST(Test, rclc_support_init_with_options) {
   rcutils_reset_error();
   rc = rclc_support_init_with_options(&support, 0, nullptr, &init_options, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
+  rcutils_reset_error();
   rc = rclc_support_init_with_options(&support, 0, nullptr, nullptr, &allocator);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
   rcutils_reset_error();

--- a/rclc/test/rclc/test_init.cpp
+++ b/rclc/test/rclc/test_init.cpp
@@ -55,10 +55,12 @@ TEST(Test, rclc_support_init_with_options) {
   rc = rclc_support_fini(&support);
   EXPECT_EQ(RCL_RET_OK, rc);
   // test invalid arguments
-  rc = rclc_support_init(nullptr, 0, nullptr, &allocator);
+  rc = rclc_support_init_with_options(nullptr, 0, nullptr, &init_options, &allocator);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
   rcutils_reset_error();
-  rc = rclc_support_init(&support, 0, nullptr, nullptr);
+  rc = rclc_support_init_with_options(&support, 0, nullptr, &init_options, nullptr);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
+  rc = rclc_support_init_with_options(&support, 0, nullptr, nullptr, &allocator);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
   rcutils_reset_error();
 }

--- a/rclc/test/rclc/test_init.cpp
+++ b/rclc/test/rclc/test_init.cpp
@@ -37,6 +37,32 @@ TEST(Test, rclc_support_init) {
   rcutils_reset_error();
 }
 
+TEST(Test, rclc_support_init_with_options) {
+  rclc_support_t support;
+  rcl_ret_t rc;
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
+
+  rc = rcl_init_options_init(&init_options, allocator);
+  EXPECT_EQ(RCL_RET_OK, rc);
+
+  rc = rclc_support_init_with_options(&support, 0, nullptr, &init_options, &allocator);
+  EXPECT_EQ(RCL_RET_OK, rc);
+  // after rcl_init context should be valid
+  ASSERT_TRUE(rcl_context_is_valid(&support.context));
+  EXPECT_EQ(&allocator, support.allocator);
+  EXPECT_TRUE(rcl_clock_valid(&support.clock));
+  rc = rclc_support_fini(&support);
+  EXPECT_EQ(RCL_RET_OK, rc);
+  // test invalid arguments
+  rc = rclc_support_init(nullptr, 0, nullptr, &allocator);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
+  rcutils_reset_error();
+  rc = rclc_support_init(&support, 0, nullptr, nullptr);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
+  rcutils_reset_error();
+}
+
 
 TEST(Test, rclc_support_fini) {
   rclc_support_t support;


### PR DESCRIPTION
This PR adds a convenience function for init with options: `rclc_support_init_with_options`.

This init function is required when default options from `rcl_get_zero_initialized_init_options` and `rcl_init_options_init` are not enough. For example when configuring underlying RMW in micro-ROS.

Please let me know your opinions about this feature.