### PR TITLE
Unused macro

### DIFF
--- a/rclc/README.md
+++ b/rclc/README.md
@@ -620,7 +620,7 @@ void my_subscriber_callback(const void * msgin)
 **Step 3:** <a name="Step3"> </a> Define a timer callback `my_timer_callback`.
 
 ```C
-#define UNUSED(x) (void)x;
+#define UNUSED(x) (void)x
 void my_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
   rcl_ret_t rc;

--- a/rclc/include/rclc/types.h
+++ b/rclc/include/rclc/types.h
@@ -49,7 +49,7 @@ typedef struct
   } while (0)
 #endif
 
-#define UNUSED(x) (void)x;
+#define UNUSED(x) (void)x
 
 #if __cplusplus
 }

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -713,7 +713,7 @@ bool rclc_executor_trigger_all(rclc_executor_handle_t * handles, unsigned int si
   RCL_CHECK_FOR_NULL_WITH_MSG(handles, "handles is NULL", return false);
   // did not use (i<size && handles[i].initialized) as loop-condition
   // because for last index i==size this would result in out-of-bound access
-  UNUSED(obj)
+  UNUSED(obj);
   for (unsigned int i = 0; i < size; i++) {
     if (handles[i].initialized) {
       if (handles[i].data_available == false) {
@@ -729,7 +729,7 @@ bool rclc_executor_trigger_all(rclc_executor_handle_t * handles, unsigned int si
 bool rclc_executor_trigger_any(rclc_executor_handle_t * handles, unsigned int size, void * obj)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(handles, "handles is NULL", return false);
-  UNUSED(obj)
+  UNUSED(obj);
   // did not use (i<size && handles[i].initialized) as loop-condition
   // because for last index i==size this would result in out-of-bound access
   for (unsigned int i = 0; i < size; i++) {
@@ -777,8 +777,8 @@ bool rclc_executor_trigger_one(rclc_executor_handle_t * handles, unsigned int si
 
 bool rclc_executor_trigger_always(rclc_executor_handle_t * handles, unsigned int size, void * obj)
 {
-  UNUSED(handles)
-  UNUSED(size)
-  UNUSED(obj)
+  UNUSED(handles);
+  UNUSED(size);
+  UNUSED(obj);
   return true;
 }

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -77,39 +77,6 @@ rclc_support_init_with_options(
 }
 
 rcl_ret_t
-rclc_support_init_with_options(
-  rclc_support_t * support,
-  int argc,
-  char const * const * argv,
-  rcl_init_options_t * init_options,
-  rcl_allocator_t * allocator)
-{
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    support, "support is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    init_options, "init_options is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator, "allocator is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-  rcl_ret_t rc = RCL_RET_OK;
-
-  memcpy(&support->init_options, init_options, sizeof(rcl_init_options_t));
-
-  support->context = rcl_get_zero_initialized_context();
-  rc = rcl_init(argc, argv, &support->init_options, &support->context);
-  if (rc != RCL_RET_OK) {
-    PRINT_RCLC_ERROR(rclc_init, rcl_init);
-    return rc;
-  }
-  support->allocator = allocator;
-
-  rc = rcl_clock_init(RCL_STEADY_TIME, &support->clock, support->allocator);
-  if (rc != RCL_RET_OK) {
-    PRINT_RCLC_ERROR(rclc_init, rcl_clock_init);
-  }
-  return rc;
-}
-
-rcl_ret_t
 rclc_support_fini(rclc_support_t * support)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -77,6 +77,39 @@ rclc_support_init_with_options(
 }
 
 rcl_ret_t
+rclc_support_init_with_options(
+  rclc_support_t * support,
+  int argc,
+  char const * const * argv,
+  rcl_init_options_t * init_options,
+  rcl_allocator_t * allocator)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    support, "support is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    init_options, "init_options is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    allocator, "allocator is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t rc = RCL_RET_OK;
+
+  memcpy(&support->init_options, init_options, sizeof(rcl_init_options_t));
+
+  support->context = rcl_get_zero_initialized_context();
+  rc = rcl_init(argc, argv, &support->init_options, &support->context);
+  if (rc != RCL_RET_OK) {
+    PRINT_RCLC_ERROR(rclc_init, rcl_init);
+    return rc;
+  }
+  support->allocator = allocator;
+
+  rc = rcl_clock_init(RCL_STEADY_TIME, &support->clock, support->allocator);
+  if (rc != RCL_RET_OK) {
+    PRINT_RCLC_ERROR(rclc_init, rcl_clock_init);
+  }
+  return rc;
+}
+
+rcl_ret_t
 rclc_support_fini(rclc_support_t * support)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(

--- a/rclc_examples/src/example_executor_trigger.c
+++ b/rclc_examples/src/example_executor_trigger.c
@@ -135,7 +135,7 @@ void my_int_subscriber_callback(const void * msgin)
   }
 }
 
-#define UNUSED(x) (void)x;
+#define UNUSED(x) (void)x
 
 void my_timer_string_callback(rcl_timer_t * timer, int64_t last_call_time)
 {


### PR DESCRIPTION
This PR fixes the usage of the UNUSED macro because it has interference with systems that has it already defined.

Before merge:

- [x] https://github.com/micro-ROS/rclc/pull/32 and rebase
- [x] Modify `client_uros_packages.repos` for all platforms to the correct branch in https://github.com/micro-ROS/micro-ros-build