### PR TITLE
Add Parameters support to RCLC

### DIFF
--- a/rclc_parameter/CMakeLists.txt
+++ b/rclc_parameter/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.5)
+project(rclc_parameter)
+
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclc REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+
+add_library(${PROJECT_NAME}
+  src/rclc_parameter/parameter.c
+  src/rclc_parameter/parameter_client.c
+  src/rclc_parameter/parameter_service.c
+)
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(${PROJECT_NAME}
+  rclc
+  rcutils
+  rcl_interfaces
+)
+
+# install
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(rcl REQUIRED)
+  find_package(rclc REQUIRED)
+  find_package(osrf_testing_tools_cpp REQUIRED)
+  find_package(std_msgs REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(${PROJECT_NAME}_test test/test_parameter.cpp)
+
+  target_include_directories(${PROJECT_NAME}_test PRIVATE include src)
+  target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})
+  ament_target_dependencies(${PROJECT_NAME}_test
+    rcl
+    rcutils
+    rosidl_runtime_c
+    osrf_testing_tools_cpp
+    std_msgs
+  )
+endif()
+
+# export dependencies
+# specific order: dependents before dependencies
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+ament_export_dependencies(ament_cmake)
+ament_export_dependencies(rcl)
+ament_export_dependencies(rcutils)
+ament_export_dependencies(rcl_interfaces)
+ament_export_dependencies(rosidl_runtime_c)
+ament_package()

--- a/rclc_parameter/include/rclc_parameter/parameter.h
+++ b/rclc_parameter/include/rclc_parameter/parameter.h
@@ -27,14 +27,17 @@ extern "C"
 #include "rcl_interfaces/msg/parameter_event.h"
 #include <rcl_interfaces/msg/detail/parameter_type__functions.h>
 
+#define RCLC_PARAMETER_NUMBER_OF_SERVICES 6
+#define RCLC_PARAMETER_NUMBER_OF_SUBSCRIPTIONS 1
+
 typedef int rclc_param_action_t;
 #define RCLC_GET_PARAMETERS 0
 #define RCLC_GET_PARAMETER_TYPES 1
 #define RCLC_SET_PARAMETERS 2
 #define RCLC_SET_PARAMETERS_ATOMICALLY 3
 #define RCLC_LIST_PARAMETERS 4
-#define RCLC_NUMBER_OF_PARAMETER_ACTIONS 5
-#define RCLC_PARAMETER_ACTION_UNKNOWN 6
+#define RCLC_DESCRIBE_PARAMETERS 5
+#define RCLC_PARAMETER_ACTION_UNKNOWN 7
 
 /// rcl_parameter_client_set_<TYPE> adds the parameter key, value pair to the
 /// pending set_parameters_request

--- a/rclc_parameter/include/rclc_parameter/parameter.h
+++ b/rclc_parameter/include/rclc_parameter/parameter.h
@@ -1,0 +1,158 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL__PARAMETER_H_
+#define RCL__PARAMETER_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcl/types.h"
+#include "rcl/visibility_control.h"
+#include "rcl/macros.h"
+#include "rcl_interfaces/msg/parameter.h"
+#include "rcl_interfaces/msg/parameter_event.h"
+#include <rcl_interfaces/msg/detail/parameter_type__functions.h>
+
+typedef int rclc_param_action_t;
+#define RCLC_GET_PARAMETERS 0
+#define RCLC_GET_PARAMETER_TYPES 1
+#define RCLC_SET_PARAMETERS 2
+#define RCLC_SET_PARAMETERS_ATOMICALLY 3
+#define RCLC_LIST_PARAMETERS 4
+#define RCLC_NUMBER_OF_PARAMETER_ACTIONS 5
+#define RCLC_PARAMETER_ACTION_UNKNOWN 6
+
+/// rcl_parameter_client_set_<TYPE> adds the parameter key, value pair to the
+/// pending set_parameters_request
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_bool(
+  rcl_interfaces__msg__Parameter * parameter, const char * parameter_name, bool value);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_integer(
+  rcl_interfaces__msg__Parameter * parameter, const char * parameter_name, int64_t value);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_double(
+  rcl_interfaces__msg__Parameter * parameter, const char * parameter_name, double value);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_string(
+  rcl_interfaces__msg__Parameter * parameter,
+  const char * parameter_name,
+  const char * value);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_bytes(
+  rcl_interfaces__msg__Parameter * parameter,
+  const char * parameter_name,
+  const uint8_t * value);
+
+// etc. for all types
+
+/// Get the boolean value of the parameter, or return error if the parameter is not a boolean.
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_get_bool(const rcl_interfaces__msg__Parameter * parameter, bool * output);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_get_int(const rcl_interfaces__msg__Parameter * parameter, int64_t * output);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_get_double(const rcl_interfaces__msg__Parameter * parameter, double * output);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_get_string(
+  const rcl_interfaces__msg__Parameter * parameter, rosidl_runtime_c__String * output);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_value_bool(
+  rcl_interfaces__msg__ParameterValue * parameter_value, bool value);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_value_integer(
+  rcl_interfaces__msg__ParameterValue * parameter_value, int64_t value);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_value_double(
+  rcl_interfaces__msg__ParameterValue * parameter_value, double value);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_value_string(
+  rcl_interfaces__msg__ParameterValue * parameter_value,
+  const char * value);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_set_value_bytes(
+  rcl_interfaces__msg__ParameterValue * parameter_value,
+  const uint8_t * value);
+
+// etc. for all types
+
+// Some other convenience function ideas:
+// Get type enum from a ParameterValue
+// rclc_parameter_get_type(rcl_interfaces__msg__ParameterValue * parameter_value, uint8 type)
+
+// Get type enum from a Parameter
+// rclc_parameter_get_type(rcl_interfaces__msg__Parameter * parameter, uint8 type)
+
+bool rclc_parameter_value_compare(
+  const rcl_interfaces__msg__ParameterValue * parameter1,
+  const rcl_interfaces__msg__ParameterValue * parameter2);
+
+// diff the new state and the old state of parameters to populate a ParameterEvent message struct
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_convert_changes_to_event(
+  const rcl_interfaces__msg__Parameter__Sequence * prior_state,
+  const rcl_interfaces__msg__Parameter__Sequence * new_state,
+  rcl_interfaces__msg__ParameterEvent * parameter_event);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCL__PARAMETER_H_

--- a/rclc_parameter/include/rclc_parameter/parameter_client.h
+++ b/rclc_parameter/include/rclc_parameter/parameter_client.h
@@ -1,0 +1,191 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL__PARAMETER_CLIENT_H_
+#define RCL__PARAMETER_CLIENT_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <rosidl_runtime_c/string_functions.h>
+#include <rcl_interfaces/msg/detail/list_parameters_result__functions.h>
+#include <rcl_interfaces/msg/detail/parameter_value__functions.h>
+#include <rcl_interfaces/msg/detail/parameter__struct.h>
+#include <rcl_interfaces/msg/detail/parameter_event__struct.h>
+#include <rcl_interfaces/msg/detail/set_parameters_result__struct.h>
+
+#include "rcl/client.h"
+#include "rcl/node.h"
+#include "rclc_parameter/parameter.h"
+#include "rcl/wait.h"
+
+/// TODO: documentation!!!
+
+/// Internal rcl implementation struct
+struct rclc_parameter_client_impl_t;
+
+/// There is no sync/async parameter client distinction in rcl.
+typedef struct rclc_parameter_client_t
+{
+  struct rclc_parameter_client_impl_t * impl;
+} rclc_parameter_client_t;
+
+typedef struct rclc_parameter_client_options_t
+{
+  // quality of service settings for all parameter-related services
+  rmw_qos_profile_t qos;
+  rcl_allocator_t allocator;
+  char * remote_node_name;
+  rmw_qos_profile_t parameter_event_qos;
+} rclc_parameter_client_options_t;
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rclc_parameter_client_options_t
+rclc_parameter_client_get_default_options(void);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rclc_parameter_client_t
+rclc_get_zero_initialized_parameter_client(void);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_init(
+  rclc_parameter_client_t * parameter_client,
+  rcl_node_t * node,
+  const rclc_parameter_client_options_t * options
+);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_init_default(
+  rclc_parameter_client_t * parameter_client,
+  rcl_node_t * node);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_fini(rclc_parameter_client_t * parameter_client);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_send_set_request(
+  const rclc_parameter_client_t * parameter_client,
+  const rcl_interfaces__msg__Parameter__Sequence * parameters,
+  int64_t * sequence_number);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_interfaces__msg__SetParametersResult__Sequence *
+rclc_parameter_client_take_set_response(
+  const rclc_parameter_client_t * parameter_client,
+  rmw_request_id_t * request_header);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_send_get_request(
+  const rclc_parameter_client_t * client,
+  const rosidl_runtime_c__String__Sequence * names,
+  int64_t * sequence_number);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_interfaces__msg__ParameterValue__Sequence *
+rclc_parameter_client_take_get_response(
+  const rclc_parameter_client_t * client,
+  rmw_request_id_t * request_header);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_send_get_types_request(
+  const rclc_parameter_client_t * client,
+  const rosidl_runtime_c__String__Sequence * parameter_names,
+  int64_t * sequence_number);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rosidl_runtime_c__uint8__Sequence *
+rclc_parameter_client_take_get_types_response(
+  const rclc_parameter_client_t * client,
+  rmw_request_id_t * request_header);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_send_set_atomically_request(
+  const rclc_parameter_client_t * client,
+  const rcl_interfaces__msg__Parameter__Sequence * parameter_values,
+  int64_t * sequence_number);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_interfaces__msg__SetParametersResult *
+rclc_parameter_client_take_set_atomically_response(
+  const rclc_parameter_client_t * client,
+  rmw_request_id_t * request_header);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_send_list_request(
+  const rclc_parameter_client_t * client,
+  const rosidl_runtime_c__String__Sequence * prefixes,
+  uint64_t depth,
+  int64_t * sequence_number);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_interfaces__msg__ListParametersResult *
+rclc_parameter_client_take_list_response(
+  const rclc_parameter_client_t * client,
+  rmw_request_id_t * request_header);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_take_event(
+  const rclc_parameter_client_t * client,
+  rcl_interfaces__msg__ParameterEvent * parameter_event,
+  rmw_message_info_t * message_info
+);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_wait_set_add_parameter_client(
+  rcl_wait_set_t * wait_set,
+  const rclc_parameter_client_t * parameter_client);
+
+// To be called after rcl_wait
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_client_get_pending_action(
+  const rcl_wait_set_t * wait_set,
+  const rclc_parameter_client_t * parameter_client,
+  rclc_param_action_t * action);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCL__PARAMETER_CLIENT_H_

--- a/rclc_parameter/include/rclc_parameter/parameter_service.h
+++ b/rclc_parameter/include/rclc_parameter/parameter_service.h
@@ -1,0 +1,188 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL__PARAMETER_SERVICE_H_
+#define RCL__PARAMETER_SERVICE_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <rosidl_runtime_c/string_functions.h>
+#include <rcl_interfaces/msg/detail/list_parameters_result__functions.h>
+#include <rcl_interfaces/msg/detail/parameter_value__functions.h>
+#include <rcl_interfaces/msg/detail/parameter__struct.h>
+#include <rcl_interfaces/msg/detail/parameter_event__struct.h>
+#include <rcl_interfaces/msg/detail/set_parameters_result__functions.h>
+
+#include "rcl/node.h"
+#include "rclc_parameter/parameter.h"
+#include "rcl/service.h"
+#include "rcl/wait.h"
+
+struct rclc_parameter_service_impl_t;
+
+typedef struct rclc_parameter_service_t
+{
+  struct rclc_parameter_service_impl_t * impl;
+} rclc_parameter_service_t;
+
+typedef struct rclc_parameter_service_options_t
+{
+  // quality of service settings for all services
+  rmw_qos_profile_t qos;
+  rmw_qos_profile_t parameter_event_qos;
+  rcl_allocator_t allocator;
+  char * remote_node_name;
+} rclc_parameter_service_options_t;
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rclc_parameter_service_options_t
+rclc_parameter_service_get_default_options(void);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rclc_parameter_service_t
+rclc_get_zero_initialized_parameter_service(void);
+
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_init(
+  rclc_parameter_service_t * parameter_service,
+  rcl_node_t * node,
+  const rclc_parameter_service_options_t * options
+);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_init_default(
+  rclc_parameter_service_t * parameter_service,
+  rcl_node_t * node);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_fini(rclc_parameter_service_t * parameter_service);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_interfaces__msg__Parameter__Sequence *
+rclc_parameter_service_take_set_request(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_send_set_response(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header,
+  const rcl_interfaces__msg__SetParametersResult__Sequence * set_parameter_results);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rosidl_runtime_c__String__Sequence *
+rclc_parameter_service_take_get_request(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_send_get_response(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header,
+  const rcl_interfaces__msg__ParameterValue__Sequence * parameters);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_send_get_types_response(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header,
+  const rosidl_runtime_c__uint8__Sequence * parameter_types);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rosidl_runtime_c__String__Sequence *
+rclc_parameter_service_take_get_types_request(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_interfaces__msg__Parameter__Sequence *
+rclc_parameter_service_take_set_atomically_request(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_send_set_atomically_response(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header,
+  const rcl_interfaces__msg__SetParametersResult * set_parameters_result);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_take_list_request(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header,
+  rosidl_runtime_c__String__Sequence * prefixes,
+  uint64_t * depth);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_send_list_response(
+  const rclc_parameter_service_t * service,
+  rmw_request_id_t * request_header,
+  const rcl_interfaces__msg__ListParametersResult * set_parameters_result);
+
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_parameter_service_publish_event(
+  const rclc_parameter_service_t * service,
+  const rcl_interfaces__msg__ParameterEvent * event);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rclc_wait_set_add_parameter_service(
+  rcl_wait_set_t * wait_set,
+  const rclc_parameter_service_t * parameter_service);
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_parameter_service_get_pending_action(
+  const rcl_wait_set_t * wait_set,
+  const rclc_parameter_service_t * parameter_service,
+  rclc_param_action_t * action
+);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCL__PARAMETER_SERVICE_H_

--- a/rclc_parameter/package.xml
+++ b/rclc_parameter/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rclc_parameter</name>
+  <version>0.1.0</version>
+  <description>rclc lifecycle convenience methods.</description>
+  <maintainer email="pablogarrido@eprosima.com">Pablo Garrido</maintainer>
+
+  <license>Apache License 2.0</license>
+  
+  <author email="pablogarrido@eprosima.com">Pablo Garrido</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclc</depend>
+  <depend>rcl_interfaces</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rclc_parameter/src/rclc_parameter/parameter.c
+++ b/rclc_parameter/src/rclc_parameter/parameter.c
@@ -1,0 +1,261 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if __cplusplus
+extern "C"
+{
+#include <string>
+#endif
+
+#include "rclc_parameter/parameter.h"
+
+#include <rcl_interfaces/msg/detail/parameter__functions.h>
+#include <rcl_interfaces/msg/detail/parameter__struct.h>
+#include <rcl_interfaces/msg/detail/parameter_event__struct.h>
+
+#include <string.h>
+#include "rosidl_runtime_c/string_functions.h"
+#include "rcl/allocator.h"
+#include "rcl/error_handling.h"
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
+
+#define RCLC_DEFINE_SET_PARAMETER(TYPE, CTYPE, ENUM_TYPE) \
+  rcl_ret_t \
+  rclc_parameter_set_ ## TYPE( \
+    rcl_interfaces__msg__Parameter * parameter, const char * parameter_name, CTYPE value) \
+  { \
+    if (!rosidl_runtime_c__String__assign(&parameter->name, parameter_name)) { \
+      return RCL_RET_ERROR; \
+    } \
+    parameter->value.type = rcl_interfaces__msg__ParameterType__ ## ENUM_TYPE; \
+    parameter->value.TYPE ## _value = value; \
+    return RCL_RET_OK; \
+  }
+
+#define RCLC_DEFINE_SET_PARAMETER_ARRAY_TYPE(TYPE, ROSIDL_TYPE, CTYPE, ENUM_TYPE) \
+  rcl_ret_t \
+  rclc_parameter_set_ ## TYPE( \
+    rcl_interfaces__msg__Parameter * parameter, const char * parameter_name, const CTYPE * value) \
+  { \
+    if (!rosidl_runtime_c__String__assign(&parameter->name, parameter_name)) { \
+      return RCL_RET_ERROR; \
+    } \
+    parameter->value.type = rcl_interfaces__msg__ParameterType__ ## ENUM_TYPE; \
+    ROSIDL_TYPE ## __assign(&parameter->value.TYPE ## _value, value); \
+    return RCL_RET_OK; \
+  }
+
+RCLC_DEFINE_SET_PARAMETER(bool, bool, PARAMETER_BOOL)
+RCLC_DEFINE_SET_PARAMETER(integer, int64_t, PARAMETER_INTEGER)
+RCLC_DEFINE_SET_PARAMETER(double, double, PARAMETER_DOUBLE)
+RCLC_DEFINE_SET_PARAMETER_ARRAY_TYPE(string, rosidl_runtime_c__String, char, PARAMETER_STRING)
+
+#define RCLC_DEFINE_SET_PARAMETER_VALUE(TYPE, CTYPE, ENUM_TYPE) \
+  rcl_ret_t \
+  rclc_parameter_set_value_ ## TYPE( \
+    rcl_interfaces__msg__ParameterValue * parameter_value, CTYPE value) \
+  { \
+    parameter_value->type = rcl_interfaces__msg__ParameterType__ ## ENUM_TYPE; \
+    parameter_value->TYPE ## _value = value; \
+    return RCL_RET_OK; \
+  }
+
+#define RCLC_DEFINE_SET_PARAMETER_VALUE_ARRAY_TYPE(TYPE, ROSIDL_TYPE, CTYPE, ENUM_TYPE) \
+  rcl_ret_t \
+  rclc_parameter_set_value_ ## TYPE( \
+    rcl_interfaces__msg__ParameterValue * parameter_value, const CTYPE * value) \
+  { \
+    parameter_value->type = rcl_interfaces__msg__ParameterType__ ## ENUM_TYPE; \
+    ROSIDL_TYPE ## __assign(&parameter_value->TYPE ## _value, value); \
+    return RCL_RET_OK; \
+  }
+
+RCLC_DEFINE_SET_PARAMETER_VALUE(bool, bool, PARAMETER_BOOL)
+RCLC_DEFINE_SET_PARAMETER_VALUE(integer, int64_t, PARAMETER_INTEGER)
+RCLC_DEFINE_SET_PARAMETER_VALUE(double, double, PARAMETER_DOUBLE)
+RCLC_DEFINE_SET_PARAMETER_VALUE_ARRAY_TYPE(string, rosidl_runtime_c__String, char, PARAMETER_STRING)
+
+// Check if two parameters are equal
+bool rclc_parameter_value_compare(
+  const rcl_interfaces__msg__ParameterValue * parameter1,
+  const rcl_interfaces__msg__ParameterValue * parameter2)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter1, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter2, RCL_RET_INVALID_ARGUMENT);
+  if (parameter1->type != parameter2->type) {
+    return false;
+  }
+  switch (parameter1->type) {
+    case rcl_interfaces__msg__ParameterType__PARAMETER_BOOL:
+      return parameter1->bool_value == parameter2->bool_value;
+    case rcl_interfaces__msg__ParameterType__PARAMETER_INTEGER:
+      return parameter1->integer_value == parameter2->integer_value;
+    case rcl_interfaces__msg__ParameterType__PARAMETER_DOUBLE:
+      return parameter1->double_value == parameter2->double_value;
+    case rcl_interfaces__msg__ParameterType__PARAMETER_STRING:
+      return strcmp(parameter1->string_value.data, parameter2->string_value.data) != 0;
+    case rcl_interfaces__msg__ParameterType__PARAMETER_NOT_SET:
+    default:
+      return false;
+  }
+
+  return false;
+}
+
+rcl_ret_t
+rclc_parameter_value_copy(
+  rcl_interfaces__msg__ParameterValue * dst,
+  const rcl_interfaces__msg__ParameterValue * src)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(dst, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(src, RCL_RET_INVALID_ARGUMENT);
+
+  dst->type = src->type;
+
+  switch (src->type) {
+    case rcl_interfaces__msg__ParameterType__PARAMETER_BOOL:
+      dst->bool_value = src->bool_value;
+      return RCL_RET_OK;
+    case rcl_interfaces__msg__ParameterType__PARAMETER_INTEGER:
+      dst->integer_value = src->integer_value;
+      return RCL_RET_OK;
+    case rcl_interfaces__msg__ParameterType__PARAMETER_DOUBLE:
+      dst->double_value = src->double_value;
+      return RCL_RET_OK;
+    case rcl_interfaces__msg__ParameterType__PARAMETER_STRING:
+      return rosidl_runtime_c__String__assign(
+        &dst->string_value, src->string_value.data) ? RCL_RET_OK : RCL_RET_ERROR;
+    case rcl_interfaces__msg__ParameterType__PARAMETER_NOT_SET:
+    default:
+      return RCL_RET_ERROR;
+  }
+  return RCL_RET_ERROR;
+}
+
+rcl_ret_t
+rclc_parameter_copy(
+  rcl_interfaces__msg__Parameter * dst,
+  const rcl_interfaces__msg__Parameter * src)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(dst, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(src, RCL_RET_INVALID_ARGUMENT);
+  if (!rosidl_runtime_c__String__assign(&dst->name, src->name.data)) {
+    return RCL_RET_ERROR;
+  }
+  return rclc_parameter_value_copy(&dst->value, &src->value);
+}
+
+rcl_ret_t
+rclc_parameter_convert_changes_to_event(
+  const rcl_interfaces__msg__Parameter__Sequence * prior_state,
+  const rcl_interfaces__msg__Parameter__Sequence * new_state,
+  rcl_interfaces__msg__ParameterEvent * parameter_event)
+{
+  // Diff the prior state and the new state and fill the parameter_event struct
+  RCL_CHECK_ARGUMENT_FOR_NULL(prior_state, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(new_state, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_event, RCL_RET_INVALID_ARGUMENT);
+
+  size_t prior_idx, new_idx;
+  size_t num_deleted_params = 0;
+  size_t num_changed_params = 0;
+  size_t num_new_params = 0;
+  // go through and count the numbers we're going to need
+  for (prior_idx = 0; prior_idx < prior_state->size; ++prior_idx) {
+    rcl_interfaces__msg__Parameter * prior_entry = &prior_state->data[prior_idx];
+    for (new_idx = 0; new_idx < new_state->size; ++new_idx) {
+      rcl_interfaces__msg__Parameter * new_entry = &new_state->data[new_idx];
+      // If the parameter has the same name but a different type or value, count it as changed.
+      if (strcmp(prior_entry->name.data, new_entry->name.data) == 0) {
+        if (!rclc_parameter_value_compare(&prior_entry->value, &new_entry->value)) {
+          num_changed_params++;
+        }
+        break;
+      }
+    }
+    if (new_idx == new_state->size) {
+      // No entry in new_state was found with a matching name to prior_entry (deleted)
+      num_deleted_params++;
+    }
+  }
+  // Could optimize this if we allocated some space to store matches from the previous comparisons
+  for (new_idx = 0; new_idx < new_state->size; ++new_idx) {
+    rcl_interfaces__msg__Parameter * new_entry = &new_state->data[new_idx];
+    for (prior_idx = 0; prior_idx < prior_state->size; ++prior_idx) {
+      rcl_interfaces__msg__Parameter * prior_entry = &prior_state->data[prior_idx];
+      if (strcmp(prior_entry->name.data, new_entry->name.data) == 0) {
+        break;
+      }
+    }
+    if (prior_idx == prior_state->size) {
+      num_new_params++;
+    }
+  }
+
+  rcl_interfaces__msg__Parameter__Sequence__fini(&parameter_event->deleted_parameters);
+  rcl_interfaces__msg__Parameter__Sequence__fini(&parameter_event->changed_parameters);
+  rcl_interfaces__msg__Parameter__Sequence__fini(&parameter_event->new_parameters);
+
+  rcl_interfaces__msg__Parameter__Sequence__init(&parameter_event->deleted_parameters,
+    num_deleted_params);
+  rcl_interfaces__msg__Parameter__Sequence__init(&parameter_event->changed_parameters,
+    num_changed_params);
+  rcl_interfaces__msg__Parameter__Sequence__init(&parameter_event->new_parameters, num_new_params);
+
+  size_t new_array_idx = 0;
+  size_t deleted_idx = 0;
+  size_t changed_idx = 0;
+
+  for (prior_idx = 0; prior_idx < prior_state->size; ++prior_idx) {
+    rcl_interfaces__msg__Parameter * prior_entry = &prior_state->data[prior_idx];
+    for (new_idx = 0; new_idx < new_state->size; ++new_idx) {
+      rcl_interfaces__msg__Parameter * new_entry = &new_state->data[new_idx];
+      // If the parameter has the same name but a different type or value, count it as changed.
+      if (strcmp(prior_entry->name.data, new_entry->name.data) == 0) {
+        if (!rclc_parameter_value_compare(&prior_entry->value, &new_entry->value)) {
+          rclc_parameter_copy(&parameter_event->changed_parameters.data[changed_idx++], new_entry);
+        }
+        break;
+      }
+    }
+    if (new_idx == new_state->size) {
+      // If no entry in new_state was found with a matching name to prior_entry, count as deleted.
+      rclc_parameter_copy(&parameter_event->deleted_parameters.data[deleted_idx++], prior_entry);
+    }
+  }
+  // Could optimize this if we allocated some space to store matches from the previous comparisons
+  for (new_idx = 0; new_idx < new_state->size; ++new_idx) {
+    rcl_interfaces__msg__Parameter * new_entry = &new_state->data[new_idx];
+    for (prior_idx = 0; prior_idx < prior_state->size; ++prior_idx) {
+      rcl_interfaces__msg__Parameter * prior_entry = &prior_state->data[prior_idx];
+      if (strcmp(prior_entry->name.data, new_entry->name.data) == 0) {
+        break;
+      }
+    }
+    if (prior_idx == prior_state->size) {
+      rclc_parameter_copy(&parameter_event->new_parameters.data[new_array_idx++], new_entry);
+    }
+  }
+  parameter_event->changed_parameters.size = num_changed_params;
+  parameter_event->deleted_parameters.size = num_deleted_params;
+  parameter_event->new_parameters.size = num_new_params;
+
+  return RCL_RET_OK;
+}
+
+#if __cplusplus
+}
+#endif

--- a/rclc_parameter/src/rclc_parameter/parameter_client.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_client.c
@@ -1,0 +1,505 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdio.h>
+
+#include <rcl_interfaces/srv/get_parameters.h>
+#include <rcl_interfaces/srv/get_parameter_types.h>
+#include <rcl_interfaces/srv/list_parameters.h>
+#include <rcl_interfaces/srv/set_parameters.h>
+#include <rcl_interfaces/srv/set_parameters_atomically.h>
+
+#include <rcl_interfaces/msg/parameter_event.h>
+#include <rcl_interfaces/msg/detail/parameter_type__functions.h>
+
+#include <string.h>
+
+#include "rmw/qos_profiles.h"
+
+#include "rcl/allocator.h"
+#include "rcl/error_handling.h"
+#include "rclc_parameter/parameter_client.h"
+#include "rcl/subscription.h"
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
+
+#include <rclc/types.h>
+
+typedef struct rclc_parameter_client_impl_t
+{
+  rclc_parameter_client_options_t options;
+  rcl_node_t * node;
+  rcl_client_t get_client;
+  rcl_client_t get_types_client;
+  rcl_client_t set_client;
+  rcl_client_t set_atomically_client;
+  rcl_client_t list_client;
+
+  rcl_subscription_t event_subscription;
+
+  rcl_interfaces__srv__GetParameters_Request get_request;
+  rcl_interfaces__srv__GetParameters_Response get_response;
+
+  rcl_interfaces__srv__GetParameterTypes_Request get_types_request;
+  rcl_interfaces__srv__GetParameterTypes_Response get_types_response;
+
+  rcl_interfaces__srv__SetParameters_Request set_request;
+  rcl_interfaces__srv__SetParameters_Response set_response;
+
+  rcl_interfaces__srv__SetParametersAtomically_Request set_atomically_request;
+  rcl_interfaces__srv__SetParametersAtomically_Response set_atomically_response;
+
+  rcl_interfaces__srv__ListParameters_Request list_request;
+  rcl_interfaces__srv__ListParameters_Response list_response;
+
+  int64_t get_sequence_number;
+  int64_t get_types_sequence_number;
+  int64_t set_sequence_number;
+  int64_t set_atomically_sequence_number;
+  int64_t list_sequence_number;
+
+  size_t wait_set_get_client_index;
+  size_t wait_set_get_types_client_index;
+  size_t wait_set_set_client_index;
+  size_t wait_set_set_atomically_client_index;
+  size_t wait_set_list_client_index;
+
+  size_t wait_set_event_subscription_index;
+} rclc_parameter_client_impl_t;
+
+rclc_parameter_client_options_t
+rclc_parameter_client_get_default_options(void)
+{
+  static rclc_parameter_client_options_t default_options;
+  default_options.qos = rmw_qos_profile_parameters;
+  default_options.parameter_event_qos = rmw_qos_profile_parameter_events;
+  default_options.allocator = rcl_get_default_allocator();
+  default_options.remote_node_name = NULL;
+  return default_options;
+}
+
+rclc_parameter_client_t
+rclc_get_zero_initialized_parameter_client(void)
+{
+  static rclc_parameter_client_t null_client = {0};
+  return null_client;
+}
+
+#define RCLC_PARAMETER_INITIALIZE_CLIENT(VERB, SRV_TYPE_NAME, SRV_SUFFIX) \
+  { \
+    const rosidl_service_type_support_t * VERB ## _ts = ROSIDL_GET_SRV_TYPE_SUPPORT( \
+      rcl_interfaces, srv, SRV_TYPE_NAME \
+      ); \
+ \
+    size_t VERB ## len = strlen(node_name) + strlen(SRV_SUFFIX) + 1; \
+    char * VERB ## _service_name = (char *)options->allocator.allocate( \
+      VERB ## len, options->allocator.state); \
+    memset(VERB ## _service_name, 0, VERB ## len); \
+    VERB ## _service_name = memcpy( \
+      VERB ## _service_name, node_name, strlen(node_name) + 1); \
+    memcpy((VERB ## _service_name + strlen(node_name)), \
+      SRV_SUFFIX, strlen(SRV_SUFFIX) + 1); \
+ \
+    ret = rcl_client_init( \
+      &parameter_client->impl->VERB ## _client, \
+      node, \
+      VERB ## _ts, \
+      VERB ## _service_name, \
+      &client_options); \
+    options->allocator.deallocate(VERB ## _service_name, options->allocator.state); \
+    if (ret != RCL_RET_OK) { \
+      fail_ret = ret; \
+      goto fail_ ## VERB; \
+    } \
+    rcl_interfaces__srv__ ## SRV_TYPE_NAME ## _Request__init( \
+      &parameter_client->impl->VERB ## _request); \
+    rcl_interfaces__srv__ ## SRV_TYPE_NAME ## _Response__init( \
+      &parameter_client->impl->VERB ## _response); \
+    parameter_client->impl->VERB ## _sequence_number = 0; \
+  } \
+
+#define RCLC_PARAMETER_CLIENT_FINI(VERB, SRV_TYPE_NAME) \
+  ret = rcl_client_fini(&parameter_client->impl->VERB ## _client, parameter_client->impl->node); \
+  if (ret != RCL_RET_OK) { \
+    fprintf(stderr, "rcl_client_fini failed for client " #VERB "\n"); \
+    fail_ret = ret; \
+  } \
+  rcl_interfaces__srv__ ## SRV_TYPE_NAME ## _Request__fini( \
+    &parameter_client->impl->VERB ## _request); \
+  rcl_interfaces__srv__ ## SRV_TYPE_NAME ## _Response__fini( \
+    &parameter_client->impl->VERB ## _response); \
+
+
+rcl_ret_t
+rclc_parameter_client_init(
+  rclc_parameter_client_t * parameter_client,
+  rcl_node_t * node,
+  const rclc_parameter_client_options_t * options
+)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ALLOCATOR_WITH_MSG(
+    &options->allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
+  const rcl_allocator_t * allocator = &options->allocator;
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_client, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
+  if (!node->impl) {
+    RCL_SET_ERROR_MSG("invalid node");
+    return RCL_RET_NODE_INVALID;
+  }
+  if (parameter_client->impl) {
+    RCL_SET_ERROR_MSG(
+      "client already initialized, or memory was uninitialized");
+    return RCL_RET_ALREADY_INIT;
+  }
+
+  rcl_ret_t ret;
+  rcl_ret_t fail_ret = RCL_RET_ERROR;
+
+  parameter_client->impl = (rclc_parameter_client_impl_t *)allocator->allocate(
+    sizeof(rclc_parameter_client_impl_t), allocator->state);
+  if (!parameter_client->impl) {
+    goto fail_alloc;
+  }
+  memset(parameter_client->impl, 0, sizeof(rclc_parameter_client_impl_t));
+
+  parameter_client->impl->node = node;
+  rcl_client_options_t client_options = rcl_client_get_default_options();
+  client_options.qos = options->qos;
+  client_options.allocator = *allocator;
+
+  const char * node_name = options->remote_node_name !=
+    NULL ? node_name = options->remote_node_name : rcl_node_get_name(node);
+
+  // Initialize all clients in impl storage
+  RCLC_PARAMETER_INITIALIZE_CLIENT(get, GetParameters, "__get_parameters");
+  RCLC_PARAMETER_INITIALIZE_CLIENT(get_types, GetParameterTypes, "__get_parameter_types");
+  RCLC_PARAMETER_INITIALIZE_CLIENT(set, SetParameters, "__set_parameters");
+  RCLC_PARAMETER_INITIALIZE_CLIENT(set_atomically, SetParametersAtomically, "__set_parameters_atomically");
+  RCLC_PARAMETER_INITIALIZE_CLIENT(list, ListParameters, "__list_parameters");
+
+  const rosidl_message_type_support_t * event_ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
+    rcl_interfaces, msg, ParameterEvent);
+  rcl_subscription_options_t subscription_options = rcl_subscription_get_default_options();
+  subscription_options.allocator = *allocator;
+  subscription_options.qos = options->parameter_event_qos;
+  const char * event_topic_name = "parameter_events";
+  parameter_client->impl->event_subscription = rcl_get_zero_initialized_subscription();
+  ret = rcl_subscription_init(
+    &parameter_client->impl->event_subscription, node, event_ts, event_topic_name,
+    &subscription_options);
+  if (ret != RCL_RET_OK) {
+    fail_ret = ret;
+    goto fail;
+  }
+
+  parameter_client->impl->options = *options;
+  return RCL_RET_OK;
+
+fail:
+  ret = rcl_subscription_fini(&parameter_client->impl->event_subscription,
+      parameter_client->impl->node);
+  if (ret != RCL_RET_OK) {
+    fail_ret = ret;
+    fprintf(stderr, "rcl_subscription_fini failed in fail block of rclc_parameter_client_init\n");
+  }
+
+fail_list:
+  RCLC_PARAMETER_CLIENT_FINI(list, ListParameters);
+
+fail_set_atomically:
+  RCLC_PARAMETER_CLIENT_FINI(set_atomically, SetParametersAtomically);
+
+fail_set:
+  RCLC_PARAMETER_CLIENT_FINI(set, SetParameters);
+
+fail_get_types:
+  RCLC_PARAMETER_CLIENT_FINI(get_types, GetParameterTypes);
+
+fail_get:
+  RCLC_PARAMETER_CLIENT_FINI(get, GetParameters);
+
+fail_alloc:
+
+  return fail_ret;
+}
+
+rcl_ret_t
+rclc_parameter_client_init_default(
+  rclc_parameter_client_t * parameter_client,
+  rcl_node_t * node)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_client, "parameter_client is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    node, "node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
+  rclc_parameter_client_options_t opts = rclc_parameter_client_get_default_options();
+  rcl_ret_t rc = rclc_parameter_client_init(parameter_client, node, &opts);
+  if (rc != RCL_RET_OK) {
+    // TODO (pablogs9): Where is ROS_PACKAGE_NAME defined?
+    // PRINT_RCLC_ERROR(rclc_parameter_client_init_default, rclc_parameter_client_init);
+  }
+  return rc;
+}
+
+
+rcl_ret_t
+rclc_parameter_client_fini(rclc_parameter_client_t * parameter_client)
+{
+  rcl_ret_t ret;
+  rcl_ret_t fail_ret = RCL_RET_OK;
+  RCLC_PARAMETER_CLIENT_FINI(get, GetParameters);
+  RCLC_PARAMETER_CLIENT_FINI(get_types, GetParameterTypes);
+  RCLC_PARAMETER_CLIENT_FINI(set, SetParameters);
+  RCLC_PARAMETER_CLIENT_FINI(set_atomically, SetParametersAtomically);
+  RCLC_PARAMETER_CLIENT_FINI(list, ListParameters);
+
+  ret = rcl_subscription_fini(&parameter_client->impl->event_subscription,
+      parameter_client->impl->node);
+  if (ret != RCL_RET_OK) {
+    fail_ret = ret;
+  }
+
+  const rcl_allocator_t * allocator = &parameter_client->impl->options.allocator;
+  allocator->deallocate(parameter_client->impl, allocator->state);
+
+  if (fail_ret != RCL_RET_OK) {
+    return fail_ret;
+  }
+  return ret;
+}
+
+
+#define DEFINE_RCLC_PARAMETER_CLIENT_SEND_REQUEST(VERB, REQUEST_SUBTYPE, SUBFIELD_NAME) \
+  rcl_ret_t \
+  rclc_parameter_client_send_ ## VERB ## _request( \
+    const rclc_parameter_client_t * parameter_client, \
+    const REQUEST_SUBTYPE * SUBFIELD_NAME, \
+    int64_t * sequence_number) \
+  { \
+    RCL_CHECK_ARGUMENT_FOR_NULL(parameter_client, RCL_RET_INVALID_ARGUMENT); \
+    RCL_CHECK_ARGUMENT_FOR_NULL(SUBFIELD_NAME, RCL_RET_INVALID_ARGUMENT); \
+    RCL_CHECK_ARGUMENT_FOR_NULL(sequence_number, RCL_RET_INVALID_ARGUMENT); \
+ \
+    parameter_client->impl->VERB ## _request.SUBFIELD_NAME = *SUBFIELD_NAME; \
+ \
+    rcl_ret_t ret = rcl_send_request( \
+      &parameter_client->impl->VERB ## _client, \
+      &parameter_client->impl->VERB ## _request, \
+      &parameter_client->impl->VERB ## _sequence_number); \
+    *sequence_number = parameter_client->impl->VERB ## _sequence_number; \
+    return ret; \
+  }
+
+DEFINE_RCLC_PARAMETER_CLIENT_SEND_REQUEST(get, rosidl_runtime_c__String__Sequence, names)
+DEFINE_RCLC_PARAMETER_CLIENT_SEND_REQUEST(get_types, rosidl_runtime_c__String__Sequence, names)
+DEFINE_RCLC_PARAMETER_CLIENT_SEND_REQUEST(set, rcl_interfaces__msg__Parameter__Sequence, parameters)
+DEFINE_RCLC_PARAMETER_CLIENT_SEND_REQUEST(set_atomically, rcl_interfaces__msg__Parameter__Sequence, parameters)
+
+rcl_ret_t
+rclc_parameter_client_send_list_request(
+  const rclc_parameter_client_t * parameter_client,
+  const rosidl_runtime_c__String__Sequence * prefixes,
+  uint64_t depth,
+  int64_t * sequence_number)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_client, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_client->impl, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ALLOCATOR_WITH_MSG(
+    &parameter_client->impl->options.allocator, "invalid allocator",
+    return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(prefixes, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(sequence_number, RCL_RET_INVALID_ARGUMENT);
+
+  parameter_client->impl->list_request.prefixes = *prefixes;
+  parameter_client->impl->list_request.depth = depth;
+
+  rcl_ret_t ret = rcl_send_request(
+    &parameter_client->impl->list_client, &parameter_client->impl->list_request,
+    &parameter_client->impl->list_sequence_number);
+  *sequence_number = parameter_client->impl->list_sequence_number;
+  return ret;
+}
+
+#define DEFINE_RCLC_PARAMETER_CLIENT_TAKE_RESPONSE(VERB, REQUEST_SUBTYPE, SUBFIELD_NAME) \
+  REQUEST_SUBTYPE * \
+  rclc_parameter_client_take_ ## VERB ## _response( \
+    const rclc_parameter_client_t * parameter_client, \
+    rmw_request_id_t * request_header) \
+  { \
+    RCL_CHECK_ARGUMENT_FOR_NULL(parameter_client, NULL); \
+ \
+    rcl_ret_t ret = rcl_take_response( \
+      &parameter_client->impl->VERB ## _client, request_header, \
+      &parameter_client->impl->VERB ## _response); \
+    if (ret != RCL_RET_OK) { \
+      return NULL; \
+    } \
+ \
+    return &parameter_client->impl->VERB ## _response.SUBFIELD_NAME; \
+  }
+
+DEFINE_RCLC_PARAMETER_CLIENT_TAKE_RESPONSE(get, rcl_interfaces__msg__ParameterValue__Sequence, values)
+DEFINE_RCLC_PARAMETER_CLIENT_TAKE_RESPONSE(get_types, rosidl_runtime_c__uint8__Sequence, types)
+DEFINE_RCLC_PARAMETER_CLIENT_TAKE_RESPONSE(set, rcl_interfaces__msg__SetParametersResult__Sequence, results)
+DEFINE_RCLC_PARAMETER_CLIENT_TAKE_RESPONSE(set_atomically, rcl_interfaces__msg__SetParametersResult, result)
+DEFINE_RCLC_PARAMETER_CLIENT_TAKE_RESPONSE(list, rcl_interfaces__msg__ListParametersResult, result)
+
+rcl_ret_t
+rclc_parameter_client_take_event(
+  const rclc_parameter_client_t * parameter_client,
+  rcl_interfaces__msg__ParameterEvent * parameter_event,
+  rmw_message_info_t * message_info
+)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_client, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_event, RCL_RET_INVALID_ARGUMENT);
+
+  rcl_ret_t ret = rcl_take(
+    &parameter_client->impl->event_subscription,
+    parameter_event,
+    message_info,
+    NULL);
+
+  return ret;
+}
+
+rcl_ret_t
+rclc_wait_set_add_parameter_client(
+  rcl_wait_set_t * wait_set,
+  const rclc_parameter_client_t * parameter_client)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(
+    parameter_client, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(
+    parameter_client->impl, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ALLOCATOR_WITH_MSG(
+    &parameter_client->impl->options.allocator, "invalid allocator",
+    return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t ret;
+
+  ret = rcl_wait_set_add_client(
+    wait_set,
+    &parameter_client->impl->get_client,
+    &parameter_client->impl->wait_set_get_client_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add get_parameters client to waitset!");
+    return ret;
+  }
+  ret = rcl_wait_set_add_client(
+    wait_set,
+    &parameter_client->impl->get_types_client,
+    &parameter_client->impl->wait_set_get_types_client_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add get_parameter_types client to waitset!");
+    return ret;
+  }
+  ret = rcl_wait_set_add_client(
+    wait_set,
+    &parameter_client->impl->set_client,
+    &parameter_client->impl->wait_set_set_client_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add set_parameters client to waitset!");
+    return ret;
+  }
+  ret = rcl_wait_set_add_client(
+    wait_set,
+    &parameter_client->impl->set_atomically_client,
+    &parameter_client->impl->wait_set_set_atomically_client_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add set_parameters_atomically client to waitset!");
+    return ret;
+  }
+  ret = rcl_wait_set_add_client(
+    wait_set,
+    &parameter_client->impl->list_client,
+    &parameter_client->impl->wait_set_list_client_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add list_parameters client to waitset!");
+    return ret;
+  }
+
+  ret = rcl_wait_set_add_subscription(
+    wait_set,
+    &parameter_client->impl->event_subscription,
+    &parameter_client->impl->wait_set_event_subscription_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add parameter events subscription to waitset!");
+    return ret;
+  }
+
+  return ret;
+}
+
+rcl_ret_t
+rclc_parameter_client_get_pending_action(
+  const rcl_wait_set_t * wait_set,
+  const rclc_parameter_client_t * parameter_client,
+  rclc_param_action_t * action)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_client, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(action, RCL_RET_INVALID_ARGUMENT);
+  size_t i = 0;
+  size_t j = 0;
+
+  for (i = 0; i < wait_set->size_of_clients; ++i) {
+    for (j = 0; j < RCLC_NUMBER_OF_PARAMETER_ACTIONS; ++j) {
+      rcl_client_t * client_ptr = NULL;
+      *action = j;
+      switch (j) {
+        case RCLC_GET_PARAMETERS:
+          client_ptr = &parameter_client->impl->get_client;
+          break;
+        case RCLC_GET_PARAMETER_TYPES:
+          client_ptr = &parameter_client->impl->get_types_client;
+          break;
+        case RCLC_SET_PARAMETERS:
+          client_ptr = &parameter_client->impl->set_client;
+          break;
+        case RCLC_SET_PARAMETERS_ATOMICALLY:
+          client_ptr = &parameter_client->impl->set_atomically_client;
+          break;
+        case RCLC_LIST_PARAMETERS:
+          client_ptr = &parameter_client->impl->list_client;
+          break;
+        default:
+          return RCL_RET_ERROR;
+      }
+      if (client_ptr == wait_set->clients[i]) {
+        return RCL_RET_OK;
+      }
+    }
+    *action = RCLC_PARAMETER_ACTION_UNKNOWN;
+  }
+  return RCL_RET_OK;
+}
+
+#if __cplusplus
+}
+#endif

--- a/rclc_parameter/src/rclc_parameter/parameter_service.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_service.c
@@ -1,0 +1,467 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <rcl_interfaces/msg/parameter_event.h>
+#include <rcl_interfaces/srv/get_parameters.h>
+#include <rcl_interfaces/srv/get_parameter_types.h>
+#include <rcl_interfaces/srv/list_parameters.h>
+#include <rcl_interfaces/srv/set_parameters.h>
+#include <rcl_interfaces/srv/set_parameters_atomically.h>
+
+#include <stdio.h>
+#include <string.h>
+#include "rmw/qos_profiles.h"
+
+#include "rcl/allocator.h"
+#include "rcl/error_handling.h"
+#include "rcl/publisher.h"
+
+#include "rclc_parameter/parameter_service.h"
+
+typedef struct rclc_parameter_service_impl_t
+{
+  rclc_parameter_service_options_t options;
+  rcl_node_t * node;
+  rcl_service_t get_service;
+  rcl_service_t get_types_service;
+  rcl_service_t set_service;
+  rcl_service_t set_atomically_service;
+  rcl_service_t list_service;
+
+  rcl_publisher_t event_publisher;
+
+  rcl_interfaces__srv__GetParameters_Request get_request;
+  rcl_interfaces__srv__GetParameters_Response get_response;
+
+  rcl_interfaces__srv__GetParameterTypes_Request get_types_request;
+  rcl_interfaces__srv__GetParameterTypes_Response get_types_response;
+
+  rcl_interfaces__srv__SetParameters_Request set_request;
+  rcl_interfaces__srv__SetParameters_Response set_response;
+
+  rcl_interfaces__srv__SetParametersAtomically_Request set_atomically_request;
+  rcl_interfaces__srv__SetParametersAtomically_Response set_atomically_response;
+
+  rcl_interfaces__srv__ListParameters_Request list_request;
+  rcl_interfaces__srv__ListParameters_Response list_response;
+
+  size_t wait_set_get_service_index;
+  size_t wait_set_get_types_service_index;
+  size_t wait_set_set_service_index;
+  size_t wait_set_set_atomilcally_service;
+  size_t wait_set_list_service_index;
+} rclc_parameter_service_impl_t;
+
+rclc_parameter_service_options_t
+rclc_parameter_service_get_default_options(void)
+{
+  static rclc_parameter_service_options_t default_options;
+  default_options.qos = rmw_qos_profile_parameters;
+  default_options.parameter_event_qos = rmw_qos_profile_parameter_events;
+  default_options.allocator = rcl_get_default_allocator();
+  default_options.remote_node_name = NULL;
+  return default_options;
+}
+
+rclc_parameter_service_t
+rclc_get_zero_initialized_parameter_service(void)
+{
+  static rclc_parameter_service_t null_service = {0};
+  return null_service;
+}
+
+#define RCL_PARAMETER_INITIALIZE_SERVICE(VERB, SRV_TYPE_NAME, SRV_SUFFIX) \
+  { \
+    const rosidl_service_type_support_t * VERB ## _ts = ROSIDL_GET_SRV_TYPE_SUPPORT( \
+      rcl_interfaces, srv, SRV_TYPE_NAME \
+      ); \
+ \
+    size_t VERB ## len = strlen(node_name) + strlen(SRV_SUFFIX) + 1; \
+    char * VERB ## _service_name = (char *)options->allocator.allocate( \
+      VERB ## len, options->allocator.state); \
+    memset(VERB ## _service_name, 0, VERB ## len); \
+    VERB ## _service_name = memcpy( \
+      VERB ## _service_name, node_name, strlen(node_name) + 1); \
+    memcpy((VERB ## _service_name + strlen(node_name)), \
+      SRV_SUFFIX, strlen(SRV_SUFFIX) + 1); \
+ \
+    ret = rcl_service_init( \
+      &parameter_service->impl->VERB ## _service, \
+      node, \
+      VERB ## _ts, \
+      VERB ## _service_name, \
+      &service_options); \
+    options->allocator.deallocate(VERB ## _service_name, options->allocator.state); \
+    if (ret != RCL_RET_OK) { \
+      fail_ret = ret; \
+      goto fail_ ## VERB; \
+    } \
+    rcl_interfaces__srv__ ## SRV_TYPE_NAME ## _Request__init( \
+      &parameter_service->impl->VERB ## _request); \
+    rcl_interfaces__srv__ ## SRV_TYPE_NAME ## _Response__init( \
+      &parameter_service->impl->VERB ## _response); \
+  } \
+
+#define RCL_PARAMETER_SERVICE_FINI(VERB, SRV_TYPE_NAME) \
+  ret = rcl_service_fini( \
+    &parameter_service->impl->VERB ## _service, parameter_service->impl->node); \
+  if (ret != RCL_RET_OK) { \
+    fprintf(stderr, "rcl_service_fini failed for service " #VERB "\n"); \
+    fail_ret = ret; \
+  } \
+  rcl_interfaces__srv__ ## SRV_TYPE_NAME ## _Request__fini( \
+    &parameter_service->impl->VERB ## _request); \
+  rcl_interfaces__srv__ ## SRV_TYPE_NAME ## _Response__fini( \
+    &parameter_service->impl->VERB ## _response); \
+
+
+rcl_ret_t
+rclc_parameter_service_init(
+  rclc_parameter_service_t * parameter_service,
+  rcl_node_t * node,
+  const rclc_parameter_service_options_t * options
+)
+{
+
+  // Check options and allocator first, so allocator can be used with errors.
+  RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&options->allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
+
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_service, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
+  if (!node->impl) {
+    RCL_SET_ERROR_MSG("invalid node");
+    return RCL_RET_NODE_INVALID;
+  }
+  if (parameter_service->impl) {
+    RCL_SET_ERROR_MSG(
+      "service already initialized, or memory was unintialized");
+    return RCL_RET_ALREADY_INIT;
+  }
+  rcl_ret_t ret;
+  rcl_ret_t fail_ret = RCL_RET_ERROR;
+  rcl_service_options_t service_options = rcl_service_get_default_options();
+  service_options.qos = options->qos;
+  service_options.allocator = options->allocator;
+
+  parameter_service->impl = (rclc_parameter_service_impl_t *)options->allocator.allocate(
+    sizeof(rclc_parameter_service_impl_t), options->allocator.state);
+  if (!parameter_service->impl) {
+    goto fail_alloc;
+  }
+  memset(parameter_service->impl, 0, sizeof(rclc_parameter_service_impl_t));
+  parameter_service->impl->node = node;
+
+  const char * node_name = options->remote_node_name !=
+    NULL ? node_name = options->remote_node_name : rcl_node_get_name(node);
+
+  // Initialize all services in impl storage
+  RCL_PARAMETER_INITIALIZE_SERVICE(get, GetParameters, "__get_parameters");
+  RCL_PARAMETER_INITIALIZE_SERVICE(get_types, GetParameterTypes, "__get_parameter_types");
+  RCL_PARAMETER_INITIALIZE_SERVICE(set, SetParameters, "__set_parameters");
+  RCL_PARAMETER_INITIALIZE_SERVICE(set_atomically, SetParametersAtomically,
+    "__set_parameters_atomically");
+  RCL_PARAMETER_INITIALIZE_SERVICE(list, ListParameters, "__list_parameters");
+
+  const rosidl_message_type_support_t * event_ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
+    rcl_interfaces, msg, ParameterEvent);
+  // TODO(jacquelinekay) Should the parameter event topic name be namespaced?
+  // Is this a configuration option?
+  rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
+  publisher_options.allocator = options->allocator;
+  publisher_options.qos = options->parameter_event_qos;
+  const char * event_topic_name = "parameter_events";
+  ret = rcl_publisher_init(
+    &parameter_service->impl->event_publisher, node, event_ts, event_topic_name,
+    &publisher_options);
+  if (ret != RCL_RET_OK) {
+    fail_ret = ret;
+    goto fail;
+  }
+
+  parameter_service->impl->options = *options;
+  return RCL_RET_OK;
+
+fail:
+  ret = rcl_publisher_fini(
+    &parameter_service->impl->event_publisher, parameter_service->impl->node);
+  if (ret != RCL_RET_OK) {
+    fail_ret = ret;
+    fprintf(stderr, "rcl_publisher_fini failed in fail block of rclc_parameter_service_init\n");
+  }
+
+fail_list:
+  RCL_PARAMETER_SERVICE_FINI(list, ListParameters);
+
+fail_set_atomically:
+  RCL_PARAMETER_SERVICE_FINI(set_atomically, SetParametersAtomically);
+
+fail_set:
+  RCL_PARAMETER_SERVICE_FINI(set, SetParameters);
+
+fail_get_types:
+  RCL_PARAMETER_SERVICE_FINI(get_types, GetParameterTypes);
+
+fail_get:
+  RCL_PARAMETER_SERVICE_FINI(get, GetParameters);
+
+fail_alloc:
+
+  return fail_ret;
+}
+
+
+rcl_ret_t
+rclc_parameter_service_init_default(
+  rclc_parameter_service_t * parameter_service,
+  rcl_node_t * node)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_service, "parameter_service is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    node, "node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
+  rclc_parameter_service_options_t opts = rclc_parameter_service_get_default_options();
+  rcl_ret_t rc = rclc_parameter_service_init(parameter_service, node, &opts);
+  if (rc != RCL_RET_OK) {
+    // TODO (pablogs9): Where is ROS_PACKAGE_NAME defined?
+    // PRINT_RCLC_ERROR(rclc_parameter_service_init_default, rclc_parameter_service_init);
+  }
+  return rc;
+}
+
+rcl_ret_t
+rclc_parameter_service_fini(rclc_parameter_service_t * parameter_service)
+{
+  rcl_ret_t ret;
+  rcl_ret_t fail_ret = RCL_RET_OK;
+  RCL_PARAMETER_SERVICE_FINI(get, GetParameters);
+  RCL_PARAMETER_SERVICE_FINI(get_types, GetParameterTypes);
+  RCL_PARAMETER_SERVICE_FINI(set, SetParameters);
+  RCL_PARAMETER_SERVICE_FINI(set_atomically, SetParametersAtomically);
+  RCL_PARAMETER_SERVICE_FINI(list, ListParameters);
+
+  ret =
+    rcl_publisher_fini(&parameter_service->impl->event_publisher, parameter_service->impl->node);
+  if (ret != RCL_RET_OK) {
+    fail_ret = ret;
+  }
+
+  rcl_allocator_t allocator = parameter_service->impl->options.allocator;
+  allocator.deallocate(parameter_service->impl, allocator.state);
+
+  if (fail_ret != RCL_RET_OK) {
+    return fail_ret;
+  }
+  return ret;
+}
+
+#define DEFINE_RCL_PARAMETER_SERVICE_TAKE_REQUEST(VERB, REQUEST_SUBTYPE, SUBFIELD_NAME) \
+  REQUEST_SUBTYPE * \
+  rclc_parameter_service_take_ ## VERB ## _request( \
+    const rclc_parameter_service_t * parameter_service, \
+    rmw_request_id_t * request_header) \
+  { \
+    RCL_CHECK_ARGUMENT_FOR_NULL(parameter_service, NULL); \
+ \
+    rcl_ret_t ret = rcl_take_request( \
+      &parameter_service->impl->VERB ## _service, request_header, \
+      &parameter_service->impl->VERB ## _request); \
+    if (ret != RCL_RET_OK) { \
+      return NULL; \
+    } \
+ \
+    return &parameter_service->impl->VERB ## _request.SUBFIELD_NAME; \
+  }
+
+DEFINE_RCL_PARAMETER_SERVICE_TAKE_REQUEST(get, rosidl_runtime_c__String__Sequence, names)
+DEFINE_RCL_PARAMETER_SERVICE_TAKE_REQUEST(get_types, rosidl_runtime_c__String__Sequence, names)
+DEFINE_RCL_PARAMETER_SERVICE_TAKE_REQUEST(set, rcl_interfaces__msg__Parameter__Sequence, parameters)
+DEFINE_RCL_PARAMETER_SERVICE_TAKE_REQUEST(set_atomically, rcl_interfaces__msg__Parameter__Sequence, parameters)
+
+rcl_ret_t
+rclc_parameter_service_take_list_request(
+  const rclc_parameter_service_t * parameter_service,
+  rmw_request_id_t * request_header,
+  rosidl_runtime_c__String__Sequence * prefixes,
+  uint64_t * depth)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(
+    parameter_service, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(prefixes, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(depth, RCL_RET_INVALID_ARGUMENT);
+
+  rcl_ret_t ret = rcl_take_request(
+    &parameter_service->impl->list_service, request_header, &parameter_service->impl->list_request);
+
+  prefixes = &parameter_service->impl->list_request.prefixes;
+  depth = &parameter_service->impl->list_request.depth;
+
+  return ret;
+}
+
+
+#define DEFINE_RCL_PARAMETER_SERVICE_SEND_RESPONSE(VERB, REQUEST_SUBTYPE, SUBFIELD_NAME) \
+  rcl_ret_t \
+  rclc_parameter_service_send_ ## VERB ## _response( \
+    const rclc_parameter_service_t * parameter_service, \
+    rmw_request_id_t * request_header, \
+    const REQUEST_SUBTYPE * SUBFIELD_NAME) \
+  { \
+    RCL_CHECK_ARGUMENT_FOR_NULL(parameter_service, RCL_RET_INVALID_ARGUMENT); \
+    RCL_CHECK_ARGUMENT_FOR_NULL(SUBFIELD_NAME, RCL_RET_INVALID_ARGUMENT); \
+ \
+    parameter_service->impl->VERB ## _response.SUBFIELD_NAME = *SUBFIELD_NAME; \
+ \
+    rcl_ret_t ret = rcl_send_response( \
+      &parameter_service->impl->VERB ## _service, request_header, \
+      &parameter_service->impl->VERB ## _response); \
+ \
+    return ret; \
+  }
+
+DEFINE_RCL_PARAMETER_SERVICE_SEND_RESPONSE(get, rcl_interfaces__msg__ParameterValue__Sequence, values)
+DEFINE_RCL_PARAMETER_SERVICE_SEND_RESPONSE(get_types, rosidl_runtime_c__uint8__Sequence, types)
+DEFINE_RCL_PARAMETER_SERVICE_SEND_RESPONSE(set, rcl_interfaces__msg__SetParametersResult__Sequence, results)
+DEFINE_RCL_PARAMETER_SERVICE_SEND_RESPONSE(set_atomically, rcl_interfaces__msg__SetParametersResult, result)
+DEFINE_RCL_PARAMETER_SERVICE_SEND_RESPONSE(list, rcl_interfaces__msg__ListParametersResult, result)
+
+rcl_ret_t
+rclc_parameter_service_publish_event(
+  const rclc_parameter_service_t * parameter_service,
+  const rcl_interfaces__msg__ParameterEvent * event)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_service, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(event, RCL_RET_INVALID_ARGUMENT);
+
+  rcl_ret_t ret = rcl_publish(&parameter_service->impl->event_publisher, event, NULL);
+
+  return ret;
+}
+
+rcl_ret_t
+rclc_wait_set_add_parameter_service(
+  rcl_wait_set_t * wait_set,
+  const rclc_parameter_service_t * parameter_service)
+{
+  rcl_ret_t ret;
+
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_service->impl, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ALLOCATOR_WITH_MSG(
+    &parameter_service->impl->options.allocator, "invalid allocator",
+    return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_INVALID_ARGUMENT);
+
+  ret = rcl_wait_set_add_service(
+    wait_set,
+    &parameter_service->impl->get_service,
+    &parameter_service->impl->wait_set_get_service_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add get_parameters service to waitset!");
+    return ret;
+  }
+  ret = rcl_wait_set_add_service(
+    wait_set,
+    &parameter_service->impl->get_types_service,
+    &parameter_service->impl->wait_set_get_types_service_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add get_parameter_types service to waitset!");
+    return ret;
+  }
+  ret = rcl_wait_set_add_service(
+    wait_set,
+    &parameter_service->impl->set_service,
+    &parameter_service->impl->wait_set_set_service_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add set_parameters service to waitset!");
+    return ret;
+  }
+  ret = rcl_wait_set_add_service(
+    wait_set,
+    &parameter_service->impl->set_atomically_service,
+    &parameter_service->impl->wait_set_set_atomilcally_service);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add set_parameters_atomically service to waitset!");
+    return ret;
+  }
+  ret = rcl_wait_set_add_service(
+    wait_set,
+    &parameter_service->impl->list_service,
+    &parameter_service->impl->wait_set_list_service_index);
+  if (ret != RCL_RET_OK) {
+    RCL_SET_ERROR_MSG(
+      "Failed to add list_parameters service to waitset!");
+    return ret;
+  }
+
+  return ret;
+}
+
+rcl_ret_t
+rcl_parameter_service_get_pending_action(
+  const rcl_wait_set_t * wait_set,
+  const rclc_parameter_service_t * parameter_service,
+  rclc_param_action_t * action)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(parameter_service, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(action, RCL_RET_INVALID_ARGUMENT);
+  size_t i = 0;
+  size_t j = 0;
+
+  for (i = 0; i < wait_set->size_of_services; ++i) {
+    for (j = 0; j < RCLC_NUMBER_OF_PARAMETER_ACTIONS; ++j) {
+      rcl_service_t * service_ptr = NULL;
+      *action = j;
+      switch (j) {
+        case RCLC_GET_PARAMETERS:
+          service_ptr = &parameter_service->impl->get_service;
+          break;
+        case RCLC_GET_PARAMETER_TYPES:
+          service_ptr = &parameter_service->impl->get_types_service;
+          break;
+        case RCLC_SET_PARAMETERS:
+          service_ptr = &parameter_service->impl->set_service;
+          break;
+        case RCLC_SET_PARAMETERS_ATOMICALLY:
+          service_ptr = &parameter_service->impl->set_atomically_service;
+          break;
+        case RCLC_LIST_PARAMETERS:
+          service_ptr = &parameter_service->impl->list_service;
+          break;
+        default:
+          *action = RCLC_PARAMETER_ACTION_UNKNOWN;
+          return RCL_RET_ERROR;
+      }
+      if (service_ptr == wait_set->services[i]) {
+        return RCL_RET_OK;
+      }
+    }
+  }
+  *action = RCLC_PARAMETER_ACTION_UNKNOWN;
+  return RCL_RET_OK;
+}
+
+#if __cplusplus
+}
+#endif

--- a/rclc_parameter/test/test_parameter.cpp
+++ b/rclc_parameter/test/test_parameter.cpp
@@ -238,7 +238,7 @@ rcl_ret_t prepare_wait_set(
   if (ret != RCL_RET_OK) {
     return ret;
   }
-  ret = rcl_wait_set_resize(wait_set, 1, 0, 0, RCLC_NUMBER_OF_PARAMETER_ACTIONS, RCLC_NUMBER_OF_PARAMETER_ACTIONS, 0);
+  ret = rcl_wait_set_resize(wait_set, 1, 0, 0, RCLC_PARAMETER_NUMBER_OF_SERVICES, RCLC_PARAMETER_NUMBER_OF_SERVICES, 0);
   if (ret != RCL_RET_OK) {
     return ret;
   }

--- a/rclc_parameter/test/test_parameter.cpp
+++ b/rclc_parameter/test/test_parameter.cpp
@@ -1,0 +1,592 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rosidl_runtime_c/string_functions.h"
+#include "rosidl_runtime_c/primitives_sequence_functions.h"
+
+#include "rcl_interfaces/msg/detail/list_parameters_result__functions.h"
+#include "rcl_interfaces/msg/detail/parameter__functions.h"
+#include "rcl_interfaces/msg/detail/parameter_type__struct.h"
+#include "rcl_interfaces/msg/detail/parameter_value__functions.h"
+#include "rcl_interfaces/msg/detail/set_parameters_result__functions.h"
+
+#include "rcl/error_handling.h"
+#include "rcl/node.h"
+#include "rclc_parameter/parameter.h"
+#include "rclc_parameter/parameter_client.h"
+#include "rclc_parameter/parameter_service.h"
+
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+
+#include "rcl/rcl.h"
+
+
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+#define WAIT_TIME -1
+// #define WAIT_TIME 1000000000
+#define NUM_PARAMS (size_t)4
+
+
+class CLASSNAME (TestParametersFixture, RMW_IMPLEMENTATION) : public ::testing::Test
+{
+public:
+  rcl_context_t * context_ptr = nullptr;
+  rcl_node_t * node_ptr = nullptr;
+  rcl_wait_set_t * wait_set = nullptr;
+  rclc_parameter_service_t * parameter_service = nullptr;
+  rclc_parameter_client_t * parameter_client = nullptr;
+
+  void SetUp()
+  {
+    rcl_ret_t ret;
+
+    rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
+    ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
+    });
+
+    this->context_ptr = new rcl_context_t;
+    *this->context_ptr = rcl_get_zero_initialized_context();
+
+    ret = rcl_init(0, nullptr, &init_options, this->context_ptr);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+    this->node_ptr = new rcl_node_t;
+    *this->node_ptr = rcl_get_zero_initialized_node();
+
+    rcl_node_options_t node_options = rcl_node_get_default_options();
+
+    ret = rcl_node_init(this->node_ptr, "parameter_node", "", this->context_ptr, &node_options);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+    this->wait_set = new rcl_wait_set_t;
+    *this->wait_set = rcl_get_zero_initialized_wait_set();
+    ret = rcl_wait_set_init(wait_set, 0, 0, 0, 0, 0, 0, this->context_ptr, rcl_get_default_allocator());
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+    this->parameter_client = new rclc_parameter_client_t;
+    *this->parameter_client = rclc_get_zero_initialized_parameter_client();
+    rclc_parameter_client_options_t cs_options = rclc_parameter_client_get_default_options();
+    ret = rclc_parameter_client_init(this->parameter_client, this->node_ptr, &cs_options);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+    this->parameter_service = new rclc_parameter_service_t;
+    *this->parameter_service = rclc_get_zero_initialized_parameter_service();
+    rclc_parameter_service_options_t ps_options = rclc_parameter_service_get_default_options();
+    ret = rclc_parameter_service_init(this->parameter_service, this->node_ptr, &ps_options);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  }
+
+  void TearDown()
+  {
+    rcl_ret_t ret;
+    if (this->wait_set) {
+      ret = rcl_wait_set_fini(this->wait_set);
+      EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+      delete this->wait_set;
+    }
+
+    if (this->parameter_service) {
+      ret = rclc_parameter_service_fini(this->parameter_service);
+      EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+      delete this->parameter_service;
+    }
+
+    if (this->parameter_client) {
+      ret = rclc_parameter_client_fini(this->parameter_client);
+      EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+      delete this->parameter_client;
+    }
+
+    if (this->node_ptr) {
+      ret = rcl_node_fini(this->node_ptr);
+      EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+      delete this->node_ptr;
+    }
+    ret = rcl_shutdown(this->context_ptr);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  }
+};
+
+// Helper function for filling in hardcoded test values
+rcl_ret_t fill_parameter_sequence(rcl_interfaces__msg__Parameter__Sequence * parameters)
+{
+  size_t parameters_idx = 0;
+  rcl_ret_t ret = rclc_parameter_set_bool(&parameters->data[parameters_idx++], "bool_param", true);
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+  ret = rclc_parameter_set_integer(&parameters->data[parameters_idx++], "int_param", 123);
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+  ret = rclc_parameter_set_double(&parameters->data[parameters_idx++], "double_param", 45.67);
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+
+  ret = rclc_parameter_set_string(
+    &parameters->data[parameters_idx++], "string_param", "hello world");
+  return ret;
+}
+
+void compare_parameter_sequence(const rcl_interfaces__msg__Parameter__Sequence * parameters)
+{
+  ASSERT_EQ(NUM_PARAMS, parameters->size);
+  size_t parameters_idx = 0;
+
+  EXPECT_EQ(0, strcmp(parameters->data[parameters_idx].name.data, "bool_param"));
+  EXPECT_TRUE(parameters->data[parameters_idx++].value.bool_value);
+
+  EXPECT_EQ(0, strcmp(parameters->data[parameters_idx].name.data, "int_param"));
+  EXPECT_EQ(123, parameters->data[parameters_idx++].value.integer_value);
+
+  EXPECT_EQ(0, strcmp(parameters->data[parameters_idx].name.data, "double_param"));
+  EXPECT_EQ(45.67, parameters->data[parameters_idx++].value.double_value);
+
+  EXPECT_EQ(0, strcmp(parameters->data[parameters_idx].name.data, "string_param"));
+  EXPECT_EQ(0, strcmp(parameters->data[parameters_idx].value.string_value.data, "hello world"));
+}
+
+void compare_parameter_sequence(const rcl_interfaces__msg__ParameterValue__Sequence * parameters)
+{
+  ASSERT_EQ(NUM_PARAMS, parameters->size);
+  size_t parameters_idx = 0;
+
+  EXPECT_TRUE(parameters->data[parameters_idx++].bool_value);
+  EXPECT_EQ(123, parameters->data[parameters_idx++].integer_value);
+  EXPECT_EQ(45.67, parameters->data[parameters_idx++].double_value);
+  EXPECT_EQ(0, strcmp(parameters->data[parameters_idx].string_value.data, "hello world"));
+}
+
+void compare_parameter_sequence(const rosidl_runtime_c__String__Sequence * parameter_names)
+{
+  ASSERT_EQ(NUM_PARAMS, parameter_names->size);
+  size_t parameters_idx = 0;
+
+  EXPECT_EQ(0, strcmp(parameter_names->data[parameters_idx++].data, "bool_param"));
+  EXPECT_EQ(0, strcmp(parameter_names->data[parameters_idx++].data, "int_param"));
+  EXPECT_EQ(0, strcmp(parameter_names->data[parameters_idx++].data, "double_param"));
+  EXPECT_EQ(0, strcmp(parameter_names->data[parameters_idx++].data, "string_param"));
+}
+
+rcl_ret_t fill_parameter_sequence(rcl_interfaces__msg__ParameterValue__Sequence * parameters)
+{
+  size_t parameters_idx = 0;
+  rcl_ret_t ret = rclc_parameter_set_value_bool(&parameters->data[parameters_idx++], true);
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+  ret = rclc_parameter_set_value_integer(&parameters->data[parameters_idx++], 123);
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+  ret = rclc_parameter_set_value_double(&parameters->data[parameters_idx++], 45.67);
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+
+  ret = rclc_parameter_set_value_string(&parameters->data[parameters_idx++], "hello world");
+  return ret;
+}
+
+bool fill_parameter_names_sequence(rosidl_runtime_c__String__Sequence * names)
+{
+  size_t parameters_idx = 0;
+  if (!rosidl_runtime_c__String__assign(&names->data[parameters_idx++], "bool_param")) {
+    return false;
+  }
+  if (!rosidl_runtime_c__String__assign(&names->data[parameters_idx++], "int_param")) {
+    return false;
+  }
+  if (!rosidl_runtime_c__String__assign(&names->data[parameters_idx++], "double_param")) {
+    return false;
+  }
+  if (!rosidl_runtime_c__String__assign(&names->data[parameters_idx++], "string_param")) {
+    return false;
+  }
+  // rosidl_runtime_c__String__assign(&names->data[parameters_idx++], "bytes_param");
+  return true;
+}
+
+rcl_ret_t prepare_wait_set(
+  rcl_wait_set_t * wait_set, rclc_parameter_service_t * parameter_service,
+  rclc_parameter_client_t * parameter_client)
+{
+  rcl_ret_t ret = rcl_wait_set_clear(wait_set);
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+  ret = rcl_wait_set_resize(wait_set, 1, 0, 0, RCLC_NUMBER_OF_PARAMETER_ACTIONS, RCLC_NUMBER_OF_PARAMETER_ACTIONS, 0);
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+  ret = rclc_wait_set_add_parameter_service(wait_set, parameter_service);
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+  ret = rclc_wait_set_add_parameter_client(wait_set, parameter_client);
+  return ret;
+}
+
+// TODO(jacquelinekay) Test un-setting parameters using set_parameters
+TEST_F(CLASSNAME(TestParametersFixture, RMW_IMPLEMENTATION), test_set_parameters) {
+  rmw_request_id_t request_header;
+  rclc_param_action_t action = RCLC_PARAMETER_ACTION_UNKNOWN;
+  rcl_ret_t ret;
+
+  rcl_interfaces__msg__Parameter__Sequence parameters;
+  EXPECT_TRUE(rcl_interfaces__msg__Parameter__Sequence__init(&parameters, NUM_PARAMS));
+
+  ret = fill_parameter_sequence(&parameters);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  int64_t seq_num;
+  ret = rclc_parameter_client_send_set_request(this->parameter_client, &parameters, &seq_num);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  ret = rcl_parameter_service_get_pending_action(wait_set, parameter_service, &action);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCLC_SET_PARAMETERS, action);
+
+  rcl_interfaces__msg__Parameter__Sequence * parameters_req = rclc_parameter_service_take_set_request(
+    this->parameter_service, &request_header);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  // Validate the request
+  compare_parameter_sequence(parameters_req);
+
+  // For now we'll just set them all to be successful
+  // Should SetParametersResult have a "name" field for the parameter key it describes?
+
+  rcl_interfaces__msg__SetParametersResult__Sequence results;
+  EXPECT_TRUE(rcl_interfaces__msg__SetParametersResult__Sequence__init(&results, NUM_PARAMS));
+
+  for (size_t i = 0; i < NUM_PARAMS; ++i) {
+    results.data[i].successful = true;
+    rosidl_runtime_c__String__assign(&results.data[i].reason, "success");
+  }
+  ret = rclc_parameter_service_send_set_response(
+    this->parameter_service, &request_header, &results);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rclc_parameter_client_get_pending_action(wait_set, parameter_client, &action);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCLC_SET_PARAMETERS, action);
+
+  rcl_interfaces__msg__SetParametersResult__Sequence * results_response =
+    rclc_parameter_client_take_set_response(this->parameter_client, &request_header);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  for (size_t i = 0; i < NUM_PARAMS; ++i) {
+    EXPECT_TRUE(results_response->data[i].successful);
+    EXPECT_EQ(0, strcmp(results.data[i].reason.data, "success"));
+  }
+
+  rcl_interfaces__msg__Parameter__Sequence prior_state;
+  EXPECT_TRUE(rcl_interfaces__msg__Parameter__Sequence__init(&prior_state, 3));
+
+  // Bogus values for the previous state: one the same, one removed, one changed
+  ret = rclc_parameter_set_integer(&prior_state.data[0], "int_param", 123);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rclc_parameter_set_integer(&prior_state.data[1], "deleted", 24);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rclc_parameter_set_double(&prior_state.data[2], "double_param", -45.67);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  rcl_interfaces__msg__ParameterEvent event;
+  EXPECT_TRUE(rcl_interfaces__msg__ParameterEvent__init(&event));
+
+  ret = rclc_parameter_convert_changes_to_event(&prior_state, parameters_req, &event);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  auto validate_event = [](const rcl_interfaces__msg__ParameterEvent & param_event) {
+      EXPECT_EQ(0, strcmp(param_event.changed_parameters.data[0].name.data, "double_param"));
+      EXPECT_EQ(45.67, param_event.changed_parameters.data[0].value.double_value);
+
+      EXPECT_EQ(0, strcmp(param_event.deleted_parameters.data[0].name.data, "deleted"));
+
+      // Ordering of new parameters doesn't matter
+      // New parameters
+      EXPECT_EQ(0, strcmp(param_event.new_parameters.data[0].name.data, "bool_param"));
+      EXPECT_TRUE(param_event.new_parameters.data[0].value.bool_value);
+
+      EXPECT_EQ(0, strcmp(param_event.new_parameters.data[1].name.data, "string_param"));
+      EXPECT_EQ(
+        0, strcmp(param_event.new_parameters.data[1].value.string_value.data, "hello world"));
+    };
+
+  validate_event(event);
+
+  ret = rclc_parameter_service_publish_event(this->parameter_service, &event);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  rcl_interfaces__msg__ParameterEvent event_response;
+  EXPECT_TRUE(rcl_interfaces__msg__ParameterEvent__init(&event_response));
+  ret = rclc_parameter_client_take_event(this->parameter_client, &event_response, nullptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  validate_event(event_response);
+}
+
+TEST_F(CLASSNAME(TestParametersFixture, RMW_IMPLEMENTATION), test_set_parameters_atomically) {
+  rmw_request_id_t request_header;
+  rclc_param_action_t action;
+  rcl_ret_t ret;
+
+  rcl_interfaces__msg__Parameter__Sequence parameters;
+  EXPECT_TRUE(rcl_interfaces__msg__Parameter__Sequence__init(&parameters, NUM_PARAMS));
+
+  rcl_interfaces__msg__SetParametersResult result;
+  EXPECT_TRUE(rcl_interfaces__msg__SetParametersResult__init(&result));
+
+  ret = fill_parameter_sequence(&parameters);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  int64_t seq_num;
+  ret = rclc_parameter_client_send_set_atomically_request(
+    this->parameter_client, &parameters, &seq_num);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_parameter_service_get_pending_action(this->wait_set, this->parameter_service, &action);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCLC_SET_PARAMETERS_ATOMICALLY, action);
+
+  rcl_interfaces__msg__Parameter__Sequence * parameters_req =
+    rclc_parameter_service_take_set_atomically_request(this->parameter_service, &request_header);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  compare_parameter_sequence(parameters_req);
+
+  // For now we'll just set them all to be successful
+  // Should SetParametersResult have a "name" field for the parameter key it describes?
+  result.successful = true;
+  rosidl_runtime_c__String__assign(&result.reason, "Because reasons");
+  ret = rclc_parameter_service_send_set_atomically_response(
+    this->parameter_service, &request_header, &result);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rclc_parameter_client_get_pending_action(this->wait_set, this->parameter_client, &action);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCLC_SET_PARAMETERS_ATOMICALLY, action);
+
+  rcl_interfaces__msg__SetParametersResult * result_response =
+    rclc_parameter_client_take_set_atomically_response(this->parameter_client, &request_header);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  EXPECT_TRUE(result_response->successful);
+  EXPECT_EQ(0, strcmp(result_response->reason.data, "Because reasons"));
+}
+
+
+TEST_F(CLASSNAME(TestParametersFixture, RMW_IMPLEMENTATION), test_get_parameters) {
+  rmw_request_id_t request_header;
+  rcl_ret_t ret;
+  rclc_param_action_t action;
+  (void) ret;
+
+  rosidl_runtime_c__String__Sequence parameter_names;
+  EXPECT_TRUE(rosidl_runtime_c__String__Sequence__init(&parameter_names, NUM_PARAMS));
+
+  rcl_interfaces__msg__ParameterValue__Sequence parameter_values;
+  EXPECT_TRUE(rcl_interfaces__msg__ParameterValue__Sequence__init(&parameter_values, NUM_PARAMS));
+
+  EXPECT_TRUE(fill_parameter_names_sequence(&parameter_names)) << rcl_get_error_string().str;
+
+  int64_t seq_num;
+  ret = rclc_parameter_client_send_get_request(
+    this->parameter_client, &parameter_names, &seq_num);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  EXPECT_EQ(RCL_RET_OK, ret);
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret);
+  ret = rcl_parameter_service_get_pending_action(this->wait_set, this->parameter_service, &action);
+  EXPECT_EQ(RCLC_GET_PARAMETERS, action);
+
+  rosidl_runtime_c__String__Sequence * request = rclc_parameter_service_take_get_request(
+    this->parameter_service, &request_header);
+  EXPECT_EQ(RCL_RET_OK, ret);
+  compare_parameter_sequence(request);
+
+  // Assign some bogus values
+  // In a real client library, these would be pulled from storage
+  ret = fill_parameter_sequence(&parameter_values);
+  EXPECT_EQ(RCL_RET_OK, ret);
+  ret = rclc_parameter_service_send_get_response(
+    this->parameter_service, &request_header, &parameter_values);
+  EXPECT_EQ(RCL_RET_OK, ret);
+
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  EXPECT_EQ(RCL_RET_OK, ret);
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret);
+  ret = rclc_parameter_client_get_pending_action(this->wait_set, this->parameter_client, &action);
+  EXPECT_EQ(RCLC_GET_PARAMETERS, action);
+
+  // TODO(jacquelinekay): Should GetParameters_Response have a Parameter__Array subfield
+  // instead of a ParameterValue__Array?
+  rcl_interfaces__msg__ParameterValue__Sequence * response = rclc_parameter_client_take_get_response(
+    this->parameter_client, &request_header);
+  EXPECT_EQ(RCL_RET_OK, ret);
+
+  compare_parameter_sequence(response);
+}
+
+
+TEST_F(CLASSNAME(TestParametersFixture, RMW_IMPLEMENTATION), test_get_parameter_types) {
+  rmw_request_id_t request_header;
+  rcl_ret_t ret;
+  rclc_param_action_t action;
+  (void) ret;
+
+  rosidl_runtime_c__String__Sequence parameter_names;
+  EXPECT_TRUE(rosidl_runtime_c__String__Sequence__init(&parameter_names, NUM_PARAMS));
+
+  rosidl_runtime_c__uint8__Sequence parameter_types;
+  EXPECT_TRUE(rosidl_runtime_c__uint8__Sequence__init(&parameter_types, NUM_PARAMS));
+
+  EXPECT_TRUE(fill_parameter_names_sequence(&parameter_names)) << rcl_get_error_string().str;
+  int64_t seq_num;
+  ret = rclc_parameter_client_send_get_types_request(this->parameter_client, &parameter_names,
+      &seq_num);
+
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret);
+  ret = rcl_parameter_service_get_pending_action(this->wait_set, this->parameter_service, &action);
+  EXPECT_EQ(RCLC_GET_PARAMETER_TYPES, action);
+
+  rosidl_runtime_c__String__Sequence * request = rclc_parameter_service_take_get_types_request(
+    this->parameter_service, &request_header);
+  compare_parameter_sequence(request);
+
+  {
+    size_t parameters_idx = 0;
+    parameter_types.data[parameters_idx++] = rcl_interfaces__msg__ParameterType__PARAMETER_BOOL;
+    parameter_types.data[parameters_idx++] = rcl_interfaces__msg__ParameterType__PARAMETER_INTEGER;
+    parameter_types.data[parameters_idx++] = rcl_interfaces__msg__ParameterType__PARAMETER_DOUBLE;
+    parameter_types.data[parameters_idx++] = rcl_interfaces__msg__ParameterType__PARAMETER_STRING;
+  }
+  ret = rclc_parameter_service_send_get_types_response(this->parameter_service, &request_header,
+      &parameter_types);
+
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret);
+  ret = rclc_parameter_client_get_pending_action(this->wait_set, this->parameter_client, &action);
+  EXPECT_EQ(RCLC_GET_PARAMETER_TYPES, action);
+
+  rosidl_runtime_c__uint8__Sequence * response = rclc_parameter_client_take_get_types_response(
+    this->parameter_client, &request_header);
+
+  {
+    size_t parameters_idx = 0;
+    EXPECT_EQ(rcl_interfaces__msg__ParameterType__PARAMETER_BOOL, response->data[parameters_idx++]);
+    EXPECT_EQ(rcl_interfaces__msg__ParameterType__PARAMETER_INTEGER,
+      response->data[parameters_idx++]);
+    EXPECT_EQ(rcl_interfaces__msg__ParameterType__PARAMETER_DOUBLE,
+      response->data[parameters_idx++]);
+    EXPECT_EQ(rcl_interfaces__msg__ParameterType__PARAMETER_STRING,
+      response->data[parameters_idx++]);
+    // EXPECT_EQ(
+    //   rcl_interfaces__msg__ParameterType__PARAMETER_BYTES, response.data[parameters_idx++]);
+  }
+}
+
+TEST_F(CLASSNAME(TestParametersFixture, RMW_IMPLEMENTATION), test_list_parameters) {
+  rmw_request_id_t request_header;
+  rcl_ret_t ret;
+  rclc_param_action_t action;
+  (void) ret;
+
+  rcl_interfaces__msg__ListParametersResult list_result;
+  EXPECT_TRUE(rcl_interfaces__msg__ListParametersResult__init(&list_result));
+  EXPECT_TRUE(rosidl_runtime_c__String__Sequence__init(&list_result.names, NUM_PARAMS));
+  EXPECT_TRUE(rosidl_runtime_c__String__Sequence__init(&list_result.prefixes, NUM_PARAMS));
+
+  rosidl_runtime_c__String__Sequence prefixes;
+  EXPECT_TRUE(rosidl_runtime_c__String__Sequence__init(&prefixes, 0));
+
+  uint64_t depth = 0;
+  int64_t seq_num;
+  ret = rclc_parameter_client_send_list_request(this->parameter_client, &prefixes, depth, &seq_num);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_parameter_service_get_pending_action(this->wait_set, this->parameter_service, &action);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCLC_LIST_PARAMETERS, action);
+
+  rosidl_runtime_c__String__Sequence prefixes_req;
+  uint64_t depth_req;
+  EXPECT_TRUE(rosidl_runtime_c__String__Sequence__init(&prefixes_req, 0));
+  ret = rclc_parameter_service_take_list_request(this->parameter_service, &request_header,
+      &prefixes_req, &depth_req);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  // put some names in
+  EXPECT_TRUE(fill_parameter_names_sequence(&list_result.names)) << rcl_get_error_string().str;
+  ret = rclc_parameter_service_send_list_response(this->parameter_service, &request_header,
+      &list_result);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  ret = prepare_wait_set(this->wait_set, this->parameter_service, this->parameter_client);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_wait(this->wait_set, WAIT_TIME);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  ret = rclc_parameter_client_get_pending_action(this->wait_set, this->parameter_client, &action);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCLC_LIST_PARAMETERS, action);
+
+  rcl_interfaces__msg__ListParametersResult * result_response =
+    rclc_parameter_client_take_list_response(this->parameter_client, &request_header);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  compare_parameter_sequence(&result_response->names);
+}


### PR DESCRIPTION
This PR add initial suppport for parameters in RCLC. This reuses the code from https://github.com/micro-ROS/rcl/tree/feature/c_parameters_uros.

This code is a low level API that directly interface with the RCL. IMO we should provide a higher level API where the user can add/delete/modify parameters and for example events are launched automatically.

A parameter server/client has:
- 5 server/clients for get, set, get_types, set_attomically and list
- 1 pub/sub for sending add/delete/modify events

I also think that this pub/sub and the server/clients should be integrated with executor.

Pending:
 - [ ] Create a higher level API when server/clients are available in RCLC executor
 - [ ] Remove branch https://github.com/micro-ROS/rcl/tree/feature/c_parameters_uros
 - [ ] Adapt micro-ROS RMW to configure parameters static memory pools