### PR TITLE
Rename UNUSED macro

### DIFF
--- a/rclc/README.md
+++ b/rclc/README.md
@@ -620,11 +620,11 @@ void my_subscriber_callback(const void * msgin)
 **Step 3:** <a name="Step3"> </a> Define a timer callback `my_timer_callback`.
 
 ```C
-#define UNUSED(x) (void)x
+#define RCLC_UNUSED(x) (void)x
 void my_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
   rcl_ret_t rc;
-  UNUSED(last_call_time);
+  RCLC_UNUSED(last_call_time);
   if (timer != NULL) {
     //printf("Timer: time since last call %d\n", (int) last_call_time);
     rc = rcl_publish(&my_pub, &pub_msg, NULL);

--- a/rclc/include/rclc/types.h
+++ b/rclc/include/rclc/types.h
@@ -49,7 +49,7 @@ typedef struct
   } while (0)
 #endif
 
-#define UNUSED(x) (void)x
+#define RCLC_UNUSED(x) (void)x
 
 #if __cplusplus
 }

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -616,7 +616,7 @@ rclc_executor_spin_some(rclc_executor_t * executor, const uint64_t timeout_ns)
   // wait up to 'timeout_ns' to receive notification about which handles reveived
   // new data from DDS queue.
   rc = rcl_wait(&executor->wait_set, timeout_ns);
-  UNUSED(rc);
+  RCLC_UNUSED(rc);
 
   // based on semantics process input data
   switch (executor->data_comm_semantics) {
@@ -668,7 +668,7 @@ rclc_executor_spin_one_period(rclc_executor_t * executor, const uint64_t period)
 
   if (executor->invocation_time == 0) {
     ret = rcutils_system_time_now(&executor->invocation_time);
-    UNUSED(ret);
+    RCLC_UNUSED(ret);
   }
   ret = rclc_executor_spin_some(executor, executor->timeout_ns);
   if (!((ret == RCL_RET_OK) || (ret == RCL_RET_TIMEOUT))) {
@@ -713,7 +713,7 @@ bool rclc_executor_trigger_all(rclc_executor_handle_t * handles, unsigned int si
   RCL_CHECK_FOR_NULL_WITH_MSG(handles, "handles is NULL", return false);
   // did not use (i<size && handles[i].initialized) as loop-condition
   // because for last index i==size this would result in out-of-bound access
-  UNUSED(obj);
+  RCLC_UNUSED(obj);
   for (unsigned int i = 0; i < size; i++) {
     if (handles[i].initialized) {
       if (handles[i].data_available == false) {
@@ -729,7 +729,7 @@ bool rclc_executor_trigger_all(rclc_executor_handle_t * handles, unsigned int si
 bool rclc_executor_trigger_any(rclc_executor_handle_t * handles, unsigned int size, void * obj)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(handles, "handles is NULL", return false);
-  UNUSED(obj);
+  RCLC_UNUSED(obj);
   // did not use (i<size && handles[i].initialized) as loop-condition
   // because for last index i==size this would result in out-of-bound access
   for (unsigned int i = 0; i < size; i++) {
@@ -777,8 +777,8 @@ bool rclc_executor_trigger_one(rclc_executor_handle_t * handles, unsigned int si
 
 bool rclc_executor_trigger_always(rclc_executor_handle_t * handles, unsigned int size, void * obj)
 {
-  UNUSED(handles);
-  UNUSED(size);
-  UNUSED(obj);
+  RCLC_UNUSED(handles);
+  RCLC_UNUSED(size);
+  RCLC_UNUSED(obj);
   return true;
 }

--- a/rclc_examples/src/example_executor.c
+++ b/rclc_examples/src/example_executor.c
@@ -39,7 +39,7 @@ void my_subscriber_callback(const void * msgin)
 void my_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
   rcl_ret_t rc;
-  UNUSED(last_call_time);
+  RCLC_UNUSED(last_call_time);
   if (timer != NULL) {
     //printf("Timer: time since last call %d\n", (int) last_call_time);
     rc = rcl_publish(&my_pub, &pub_msg, NULL);

--- a/rclc_examples/src/example_executor_convenience.c
+++ b/rclc_examples/src/example_executor_convenience.c
@@ -39,7 +39,7 @@ void my_subscriber_callback(const void * msgin)
 void my_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
   rcl_ret_t rc;
-  UNUSED(last_call_time);
+  RCLC_UNUSED(last_call_time);
   if (timer != NULL) {
     //printf("Timer: time since last call %d\n", (int) last_call_time);
     rc = rcl_publish(&my_pub, &pub_msg, NULL);

--- a/rclc_examples/src/example_executor_trigger.c
+++ b/rclc_examples/src/example_executor_trigger.c
@@ -135,12 +135,12 @@ void my_int_subscriber_callback(const void * msgin)
   }
 }
 
-#define UNUSED(x) (void)x
+#define RCLC_UNUSED(x) (void)x
 
 void my_timer_string_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
   rcl_ret_t rc;
-  UNUSED(last_call_time);
+  RCLC_UNUSED(last_call_time);
   if (timer != NULL) {
     //printf("Timer: time since last call %d\n", (int) last_call_time);
 
@@ -167,7 +167,7 @@ void my_timer_string_callback(rcl_timer_t * timer, int64_t last_call_time)
 void my_timer_int_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
   rcl_ret_t rc;
-  UNUSED(last_call_time);
+  RCLC_UNUSED(last_call_time);
   if (timer != NULL) {
     //printf("Timer: time since last call %d\n", (int) last_call_time);
     int_pub_msg.data = int_pub_value++;


### PR DESCRIPTION
The name `UNUSED` can potentially (I have found a couple of cases) collide with another library definitions and raise a warning at build time.

I propose changing the name to `RCLC_UNUSED` or not defining it in a public header.