### PR TITLE
fixed rename of UNUSED macro in unit tests of rclc executor

### DIFF
--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -241,7 +241,7 @@ void spin_period_callback(const void * msgin)
 {
   rcutils_time_point_value_t now;
   rcl_ret_t rc;
-  RCL_UNUSED(msgin);
+  RCLC_UNUSED(msgin);
 
   rc = rcutils_system_time_now(&now);
   if (rc != RCL_RET_OK) {
@@ -270,7 +270,7 @@ uint64_t test_case_evaluate_spin_period()
 // timer callback
 void my_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
-  RCL_UNUSED(last_call_time);
+  RCLC_UNUSED(last_call_time);
   // Do timer work...
   // Optionally reconfigure, cancel, or reset the timer...
   if (timer != NULL) {

--- a/rclc/test/rclc/test_timer.cpp
+++ b/rclc/test/rclc/test_timer.cpp
@@ -18,8 +18,8 @@
 
 void my_callback(rcl_timer_t * timer, int64_t last_call)
 {
-  RCL_UNUSED(timer);
-  RCL_UNUSED(last_call);
+  RCLC_UNUSED(timer);
+  RCLC_UNUSED(last_call);
 }
 
 TEST(Test, rclc_timer_init_default) {


### PR DESCRIPTION
See PR https://github.com/micro-ROS/rclc/pull/41

Signed-off-by: Staschulat Jan <jan.staschulat@de.bosch.com>