### PR TITLE
updated package description

### DIFF
--- a/rclc_examples/package.xml
+++ b/rclc_examples/package.xml
@@ -2,8 +2,8 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclc_examples</name>
-  <version>0.1.1</version>
-  <description>Examples of using rclc</description>
+  <version>0.1.2</version>
+  <description>Example of using rclc_executor</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
 
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Preparation of PR https://github.com/ros2/rclc/pull/22 from micro-ROS/rclc:master to ros2/rclc:master
- needs correction of version number in a package.xml file 
- probably forgot to pull ros2/rclc:master into micro-ROS/rclc:master after release generation of ros2/rclc (which required to increment version numbers)


Signed-off-by: Staschulat Jan <jan.staschulat@de.bosch.com>