### PR TITLE
Update rclc_node_init_with_options test

### DIFF
--- a/rclc/test/rclc/test_node.cpp
+++ b/rclc/test/rclc/test_node.cpp
@@ -102,7 +102,6 @@ TEST(Test, rclc_node_init_with_options) {
   rcutils_reset_error();
 
   // test with valid arguments
-  node_options.domain_id = 4;
   rc = rclc_node_init_with_options(
     &node, my_name, my_namespace, &support, &node_options);
   EXPECT_EQ(RCL_RET_OK, rc);


### PR DESCRIPTION
This PR remove a line that sets the domain id during testing the function `rclc_node_init_with_options()`. Is not necessary to set this when testing the proper operation of this funcion, it is enough retrieving this provided options with  `rcl_node_get_default_options()`