### PR TITLE
Bugfix/pr ros2 rclc 22

### DIFF
--- a/rclc/include/rclc/types.h
+++ b/rclc/include/rclc/types.h
@@ -44,7 +44,20 @@ typedef struct
   do { \
     RCUTILS_LOG_ERROR_NAMED( \
       ROS_PACKAGE_NAME, \
-      "[" #rclc "] error in " #rcl ": %s\n", rcutils_get_error_string().str); \
+      "[" #rclc "] Error in " #rcl ": %s\n", rcutils_get_error_string().str); \
+    rcl_reset_error(); \
+  } while (0)
+#endif
+
+/**
+ * macro to print warnings
+ */
+#ifndef PRINT_RCLC_WARN
+#define PRINT_RCLC_WARN(rclc, rcl) \
+  do { \
+    RCUTILS_LOG_WARN_NAMED( \
+      ROS_PACKAGE_NAME, \
+      "[" #rclc "] Warning in " #rcl ": %s\n", rcutils_get_error_string().str); \
     rcl_reset_error(); \
   } while (0)
 #endif

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -88,12 +88,12 @@ rclc_support_fini(rclc_support_t * support)
   rcl_ret_t rc;
   rc = rcl_init_options_fini(&support->init_options);
   if (rc != RCL_RET_OK) {
-    PRINT_RCLC_ERROR(rclc_init_fini, rcl_init_options_fini);
+    PRINT_RCLC_WARN(rclc_init_fini, rcl_init_options_fini);
     return rc;
   }
   rc = rcl_clock_fini(&support->clock);
   if (rc != RCL_RET_OK) {
-    PRINT_RCLC_ERROR(rclc_init_fini, rcl_clock_fini);
+    PRINT_RCLC_WARN(rclc_init_fini, rcl_clock_fini);
   }
   return rc;
 }

--- a/rclc/src/rclc/node.c
+++ b/rclc/src/rclc/node.c
@@ -43,7 +43,9 @@ rclc_node_init_default(
     namespace_,
     support,
     &node_ops);
-
+  if (rc != RCL_RET_OK) {
+    PRINT_RCLC_WARN(rclc_node_init_default, rclc_node_init_with_options);
+  }
   return rc;
 }
 
@@ -74,7 +76,7 @@ rclc_node_init_with_options(
     &support->context,
     node_ops);
   if (rc != RCL_RET_OK) {
-    PRINT_RCLC_ERROR(rclc_node_init_default, rcl_node_init_with_options);
+    PRINT_RCLC_WARN(rclc_node_init_with_options, rcl_node_init);
   }
   return rc;
 }

--- a/rclc/test/rclc/test_node.cpp
+++ b/rclc/test/rclc/test_node.cpp
@@ -22,7 +22,7 @@ TEST(Test, rclc_node_init_default) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
   EXPECT_EQ(RCL_RET_OK, rc);
-  const char * my_name = "test_name";
+  const char * my_name = "test_node";
   const char * my_namespace = "test_namespace";
   rcl_node_t node = rcl_get_zero_initialized_node();
 
@@ -61,6 +61,10 @@ TEST(Test, rclc_node_init_default) {
   rcutils_reset_error();
 
   // clean up
+  rc = rcl_node_fini(&node);
+  EXPECT_EQ(RCL_RET_OK, rc);
+  rcutils_reset_error();
+
   rc = rclc_support_fini(&support);
   EXPECT_EQ(RCL_RET_OK, rc);
 }
@@ -71,7 +75,7 @@ TEST(Test, rclc_node_init_with_options) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
   EXPECT_EQ(RCL_RET_OK, rc);
-  const char * my_name = "test_name";
+  const char * my_name = "test_node";
   const char * my_namespace = "test_namespace";
   rcl_node_t node = rcl_get_zero_initialized_node();
   rcl_node_options_t node_options = rcl_node_get_default_options();
@@ -107,6 +111,10 @@ TEST(Test, rclc_node_init_with_options) {
   EXPECT_EQ(RCL_RET_OK, rc);
 
   // clean up
+  rc = rcl_node_fini(&node);
+  EXPECT_EQ(RCL_RET_OK, rc);
+  rcutils_reset_error();
+
   rc = rclc_support_fini(&support);
   EXPECT_EQ(RCL_RET_OK, rc);
 }

--- a/rclc/test/rclc/test_publisher.cpp
+++ b/rclc/test/rclc/test_publisher.cpp
@@ -24,10 +24,11 @@ TEST(Test, rclc_publisher_init_default) {
   // preliminary setup
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
-  const char * my_name = "test_name";
+  const char * my_name = "test_pub";
   const char * my_namespace = "test_namespace";
   rcl_node_t node = rcl_get_zero_initialized_node();
   rc = rclc_node_init_default(&node, my_name, my_namespace, &support);
+  EXPECT_EQ(RCL_RET_OK, rc);
 
   // test with valid arguments
   rcl_publisher_t publisher = rcl_get_zero_initialized_publisher();
@@ -49,6 +50,7 @@ TEST(Test, rclc_publisher_init_default) {
   rc = rclc_publisher_init_default(&publisher, &node, type_support, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
   rcutils_reset_error();
+
   // clean up
   rc = rcl_publisher_fini(&publisher, &node);
   EXPECT_EQ(RCL_RET_OK, rc);
@@ -65,7 +67,7 @@ TEST(Test, rclc_publisher_init_best_effort) {
   // preliminary setup
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
-  const char * my_name = "test_name";
+  const char * my_name = "test_pub_be";
   const char * my_namespace = "test_namespace";
   rcl_node_t node = rcl_get_zero_initialized_node();
   rc = rclc_node_init_default(&node, my_name, my_namespace, &support);

--- a/rclc_lifecycle/src/rclc_lifecycle/rclc_lifecycle.c
+++ b/rclc_lifecycle/src/rclc_lifecycle/rclc_lifecycle.c
@@ -165,8 +165,6 @@ rclc_lifecycle_register_callback(
   RCL_CHECK_FOR_NULL_WITH_MSG(
     lifecycle_node, "node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    goal_state, "goal_state is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
     cb, "callback is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   lifecycle_node->callbacks.goal_states[goal_state] = true;

--- a/rclc_lifecycle/test/test_lifecycle.cpp
+++ b/rclc_lifecycle/test/test_lifecycle.cpp
@@ -74,9 +74,18 @@ TEST(TestRclcLifecycle, lifecycle_node) {
     &allocator);
 
   EXPECT_EQ(RCL_RET_OK, res);
+
   EXPECT_EQ(
     RCL_RET_OK,
     rcl_lifecycle_state_machine_is_initialized(lifecycle_node.state_machine));
+
+  // clean up
+  res = rcl_node_fini(&my_node);
+  EXPECT_EQ(RCL_RET_OK, res);
+  res = rcl_node_options_fini(&node_ops);
+  EXPECT_EQ(RCL_RET_OK, res);
+  res = rcl_init_options_fini(&init_options);
+  EXPECT_EQ(RCL_RET_OK, res);
 }
 
 TEST(TestRclcLifecycle, lifecycle_node_transitions) {
@@ -139,6 +148,13 @@ TEST(TestRclcLifecycle, lifecycle_node_transitions) {
   EXPECT_EQ(
     lifecycle_msgs__msg__State__PRIMARY_STATE_UNCONFIGURED,
     lifecycle_node.state_machine->current_state->id);
+
+  res = rcl_node_fini(&my_node);
+  EXPECT_EQ(RCL_RET_OK, res);
+  res = rcl_node_options_fini(&node_ops);
+  EXPECT_EQ(RCL_RET_OK, res);
+  res = rcl_init_options_fini(&init_options);
+  EXPECT_EQ(RCL_RET_OK, res);
 }
 
 TEST(TestRclcLifecycle, lifecycle_node_callbacks) {
@@ -188,4 +204,11 @@ TEST(TestRclcLifecycle, lifecycle_node_callbacks) {
 
   EXPECT_EQ(RCL_RET_OK, res);
   EXPECT_EQ(15, callback_mockup_counter);
+
+  res = rcl_node_fini(&my_node);
+  EXPECT_EQ(RCL_RET_OK, res);
+  res = rcl_node_options_fini(&node_ops);
+  EXPECT_EQ(RCL_RET_OK, res);
+  res = rcl_init_options_fini(&init_options);
+  EXPECT_EQ(RCL_RET_OK, res);
 }


### PR DESCRIPTION
Bugfixes for https://github.com/ros2/rclc/pull/22
- [rclc_lifecycle] resolved compiler warning: wrong usage of argument check
- [rclc rclc_lifecycle] resolved bug in unit_test for Dashing, Eloquent: missing clean-up code for node/publisher etc. at the end of unit tests(these objects were used with the same name in next unit test again"
- [rclc] added RCLC_WARN macro so that unit_test output is not seen as an error. Because these errors were intentionally created.

For next release:
@norro Please add argument checks for NULL pointer in all your functions.