### PR TITLE
Bugfix/pr22 unit test executor timing 

### DIFF
--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -28,8 +28,8 @@
 #endif
 
 
-// default timeout for rcl_wait() is 100ms
-#define DEFAULT_WAIT_TIMEOUT_MS 100000000
+// default timeout for rcl_wait() is 1000ms
+#define DEFAULT_WAIT_TIMEOUT_NS 1000000000
 
 // declarations of helper functions
 /*
@@ -114,7 +114,7 @@ rclc_executor_init(
   executor->index = 0;
   executor->wait_set = rcl_get_zero_initialized_wait_set();
   executor->allocator = allocator;
-  executor->timeout_ns = DEFAULT_WAIT_TIMEOUT_MS;
+  executor->timeout_ns = DEFAULT_WAIT_TIMEOUT_NS;
   // allocate memory for the array
   executor->handles =
     executor->allocator->allocate(
@@ -192,7 +192,7 @@ rclc_executor_fini(rclc_executor_t * executor)
         PRINT_RCLC_ERROR(rclc_executor_fini, rcl_wait_set_fini);
       }
     }
-    executor->timeout_ns = DEFAULT_WAIT_TIMEOUT_MS;
+    executor->timeout_ns = DEFAULT_WAIT_TIMEOUT_NS;
   } else {
     // Repeated calls to fini or calling fini on a zero initialized executor is ok
   }

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -63,6 +63,13 @@ static unsigned int _cb5_int_value = 0;
 rcl_publisher_t * _pub_int_ptr;
 std_msgs__msg__Int32 * _pub_int_msg_ptr;
 
+// sleep time beween publish and receive in DDS middleware
+// to allow enough time on CI jobs (in milliseconds)
+#define RCLC_UNIT_TEST_SLEEP_TIME_MS 500
+
+// timeout for rcl_wait() when calling spin_some API of executor
+const uint64_t rclc_test_timeout_ns = 1000000000;  // 1s
+
 static
 void
 _results_callback_counters_init()
@@ -655,8 +662,7 @@ TEST_F(TestDefaultExecutor, executor_spin_some_API) {
   rc = rclc_executor_add_timer(&executor, &this->timer1);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
-  const unsigned int timeout_ms = 100;
-  rc = rclc_executor_spin_some(&executor, timeout_ms);
+  rc = rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
   // tear down
@@ -680,9 +686,8 @@ TEST_F(TestDefaultExecutor, pub_sub_example) {
   bool success = false;
   unsigned int tries;
   unsigned int max_tries = 100;
-  unsigned int wait_timeout_ms = 10;
   _wait_for_msg(
-    &this->sub1, &this->context, max_tries, wait_timeout_ms, &tries,
+    &this->sub1, &this->context, max_tries, rclc_test_timeout_ns, &tries,
     &success);
   // printf("Number of tries to access DDS-queue: %u\n", tries);
   ASSERT_TRUE(success);
@@ -752,19 +757,17 @@ TEST_F(TestDefaultExecutor, spin_some_sequential_execution) {
   bool success = false;
   unsigned int tries;
   unsigned int max_tries = 100;
-  unsigned int wait_timeout_ms = 10;
   // process subscriptions
   for (unsigned int i = 0; i < 100; i++) {
-    const unsigned int timeout_ms = 100;
     // Assumption: messages for all sub1, sub2 and sub3 are available
-    _wait_for_msg(&this->sub1, &this->context, max_tries, wait_timeout_ms, &tries, &success);
+    _wait_for_msg(&this->sub1, &this->context, max_tries, rclc_test_timeout_ns, &tries, &success);
     ASSERT_TRUE(success);
-    _wait_for_msg(&this->sub2, &this->context, max_tries, wait_timeout_ms, &tries, &success);
+    _wait_for_msg(&this->sub2, &this->context, max_tries, rclc_test_timeout_ns, &tries, &success);
     ASSERT_TRUE(success);
-    _wait_for_msg(&this->sub3, &this->context, max_tries, wait_timeout_ms, &tries, &success);
+    _wait_for_msg(&this->sub3, &this->context, max_tries, rclc_test_timeout_ns, &tries, &success);
     ASSERT_TRUE(success);
 
-    ret = rclc_executor_spin_some(&executor, timeout_ms);
+    ret = rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
     if ((ret == RCL_RET_OK) || (ret == RCL_RET_TIMEOUT)) {
       // valid return values
     } else {
@@ -803,16 +806,14 @@ TEST_F(TestDefaultExecutor, spin_some_sequential_execution) {
 
   // process subscriptions. Assumption: messages for all sub1, sub2 and sub3 are available
   for (unsigned int i = 0; i < 100; i++) {
-    const unsigned int timeout_ms = 100;
-
     // wait until messages are received
-    _wait_for_msg(&this->sub1, &this->context, max_tries, wait_timeout_ms, &tries, &success);
+    _wait_for_msg(&this->sub1, &this->context, max_tries, rclc_test_timeout_ns, &tries, &success);
     ASSERT_TRUE(success);
-    _wait_for_msg(&this->sub2, &this->context, max_tries, wait_timeout_ms, &tries, &success);
+    _wait_for_msg(&this->sub2, &this->context, max_tries, rclc_test_timeout_ns, &tries, &success);
     ASSERT_TRUE(success);
-    _wait_for_msg(&this->sub3, &this->context, max_tries, wait_timeout_ms, &tries, &success);
+    _wait_for_msg(&this->sub3, &this->context, max_tries, rclc_test_timeout_ns, &tries, &success);
     ASSERT_TRUE(success);
-    ret = rclc_executor_spin_some(&executor, timeout_ms);
+    ret = rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
     if ((ret == RCL_RET_OK) || (ret == RCL_RET_TIMEOUT)) {
       // valid return values
     } else {
@@ -907,13 +908,12 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   bool success = false;
   unsigned int tries;
   unsigned int max_tries = 100;
-  unsigned int timeout_ms = 10;
   _wait_for_msg(
-    &this->sub1, &this->context, max_tries, timeout_ms, &tries,
+    &this->sub1, &this->context, max_tries, rclc_test_timeout_ns, &tries,
     &success);
   ASSERT_TRUE(success);
   _wait_for_msg(
-    &this->sub2, &this->context, max_tries, timeout_ms, &tries,
+    &this->sub2, &this->context, max_tries, rclc_test_timeout_ns, &tries,
     &success);
   ASSERT_TRUE(success);
 
@@ -924,8 +924,7 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   // running the executor
   unsigned int max_iterations = 2;
   for (unsigned int i = 0; i < max_iterations; i++) {
-    const unsigned int timeout_ms = 100;
-    ret = rclc_executor_spin_some(&executor, timeout_ms);
+    ret = rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
     if ((ret == RCL_RET_OK) || (ret == RCL_RET_TIMEOUT)) {
       // valid return values
     } else {
@@ -951,8 +950,6 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   executor = rclc_executor_get_zero_initialized_executor();
   ret = rclc_executor_init(&executor, &this->context, 2, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
-  const unsigned int timeout_ms = 100;
   _results_callback_init();
 
   // initially the wait_set is zero_initialized
@@ -988,17 +985,16 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   bool success = false;
   unsigned int tries;
   unsigned int max_tries = 100;
-  unsigned int wait_timeout_ms = 10;
   _wait_for_msg(
-    &this->sub1, &this->context, max_tries, wait_timeout_ms, &tries,
+    &this->sub1, &this->context, max_tries, rclc_test_timeout_ns, &tries,
     &success);
   ASSERT_TRUE(success);
   _wait_for_msg(
-    &this->sub2, &this->context, max_tries, wait_timeout_ms, &tries,
+    &this->sub2, &this->context, max_tries, rclc_test_timeout_ns, &tries,
     &success);
   ASSERT_TRUE(success);
 
-  ret = rclc_executor_spin_some(&executor, timeout_ms);
+  ret = rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   if ((ret == RCL_RET_OK) || (ret == RCL_RET_TIMEOUT)) {
     // valid return values
   } else {
@@ -1032,7 +1028,7 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   ///////////////////////////////////////////////////////////////////////////////////
   _cb1_int_value = 0;
   _cb2_int_value = 0;
-  ret = rclc_executor_spin_some(&executor, timeout_ms);
+  ret = rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   if ((ret == RCL_RET_OK) || (ret == RCL_RET_TIMEOUT)) {
     // valid return values
   } else {
@@ -1157,9 +1153,8 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1(tc) did not publish!";
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  const uint64_t timeout_ns = 10000000;  // 10ms
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   // test result
   EXPECT_EQ(_cb5_int_value, (unsigned int) 2) <<
     " expect value 2: Value from callback of int32_callback4 should be received.";
@@ -1243,9 +1238,8 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1(tc) did not publish!";
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  const uint64_t timeout_ns = 10000000;  // 10ms
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   // test result
   EXPECT_EQ(
     _cb5_int_value,
@@ -1303,7 +1297,6 @@ TEST_F(TestDefaultExecutor, trigger_one) {
     &CALLBACK_2, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  const uint64_t timeout_ns = 10000000;  // 10ms
   // ------------------------- test case setup ---------------------------------------------
 
   // first round
@@ -1311,8 +1304,8 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
@@ -1321,8 +1314,8 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   this->pub2_msg.data = 7;
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A not called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
@@ -1332,8 +1325,8 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   this->pub1_msg.data = 11;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 11) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 2);
@@ -1381,7 +1374,6 @@ TEST_F(TestDefaultExecutor, trigger_any) {
     &CALLBACK_2, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  const uint64_t timeout_ns = 10000000;  // 10ms
   // ------------------------- test case setup --------------------------------------------
   // first round
   _results_callback_init();
@@ -1389,8 +1381,8 @@ TEST_F(TestDefaultExecutor, trigger_any) {
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
@@ -1399,8 +1391,8 @@ TEST_F(TestDefaultExecutor, trigger_any) {
   this->pub2_msg.data = 7;
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A not called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
@@ -1412,8 +1404,8 @@ TEST_F(TestDefaultExecutor, trigger_any) {
   _cb2_int_value = 0;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 11) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 2);
@@ -1461,7 +1453,6 @@ TEST_F(TestDefaultExecutor, trigger_all) {
     &CALLBACK_2, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  const uint64_t timeout_ns = 10000000;  // 10ms
   // ------------------------- test case setup --------------------------------------------
   // first round
   _results_callback_init();
@@ -1469,8 +1460,8 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 0) << " expected: A not called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 0);
@@ -1479,8 +1470,8 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   this->pub2_msg.data = 7;
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
@@ -1492,8 +1483,8 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   _cb2_int_value = 0;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 0) << " expected: A not called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
@@ -1538,12 +1529,11 @@ TEST_F(TestDefaultExecutor, trigger_always) {
     &CALLBACK_2, ALWAYS);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  const uint64_t timeout_ns = 10000000;  // 10ms
   // ------------------------- test case setup --------------------------------------------
   // first round
   _results_callback_init();
   _executor_results_init();
-  rclc_executor_spin_some(&executor, timeout_ns);
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 0);
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0);
   EXPECT_EQ(_cb1_cnt, (unsigned int) 0) << " expected: A not called";
@@ -1552,8 +1542,8 @@ TEST_F(TestDefaultExecutor, trigger_always) {
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(250));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1) << " expected: A called";
@@ -1564,8 +1554,8 @@ TEST_F(TestDefaultExecutor, trigger_always) {
   _cb2_int_value = 0;
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
-  std::this_thread::sleep_for(std::chrono::milliseconds(250));
-  rclc_executor_spin_some(&executor, timeout_ns);
+  std::this_thread::sleep_for(std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS));
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 0) << " expected: A not called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);


### PR DESCRIPTION
resolves bugs in PR22 ros2/rclc due to timing issues in unit test of executor
- increased timeout_ns to 1s (waiting time in rcl_wait)
- increased hard-set waiting time between publish and executor_spin_some call to 500ms (up from 100ms)
  (actually increasing timeout_ns to 1s should be sufficient)
- changed default value of timeout_ns in rclc_executor to 1s
- simplified unit tests
  - one global variable for timeout_ns (== 1s)
  - one global variable for sleep_time (==500ms)
