### PR TITLE
Fix build error in PR 22 on ros2/rclc for rclc_lifecycle. 

### DIFF
--- a/rclc_lifecycle/package.xml
+++ b/rclc_lifecycle/package.xml
@@ -10,12 +10,13 @@
   
   <author email="arne.nordmann@de.bosch.com">Arne Nordmann</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>rclc</depend>
   <depend>rcl_lifecycle</depend>
   <depend>lifecycle_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>osrf_testing_tools_cpp</test_depend>


### PR DESCRIPTION
Hint from Michael Carroll:

Von: Michael Carroll <michael@openrobotics.org>
Gesendet: Dienstag, 24. November 2020 15:14
An: Staschulat Jan (CR/ADT3)
Betreff: Re: Question regarding failed build of rclc_lifecycle package (rclc repo)

Sometimes the `binarydeb` output is difficult to parse, because it is very verbose on failure.

It seems that the failure was actually in the `cmake configure` stage:

01:03:23 CMake Error at CMakeLists.txt:54 (find_package): 01:03:23 By not providing "Findament_cmake_gtest.cmake" in CMAKE_MODULE_PATH this 01:03:23 project has asked CMake to find a package configuration file provided by 01:03:23 "**ament_cmake_gtest**", **but CMake did not find one**. 01:03:23 01:03:23 Could not find a package configuration file provided by "ament_cmake_gtest" 01:03:23 with any of the following names: 01:03:23 01:03:23 ament_cmake_gtestConfig.cmake 01:03:23 ament_cmake_gtest-config.cmake 01:03:23 01:03:23 Add the installation prefix of "ament_cmake_gtest" to CMAKE_PREFIX_PATH or 01:03:23 set "ament_cmake_gtest_DIR" to a directory containing one of the above 01:03:23 files. If "ament_cmake_gtest" provides a separate development package or 01:03:23 SDK, be sure it has been installed. 01:03:23 01:03:23 01:03:23 -- Configuring incomplete, errors occurred!

I took a quick look at your package.xml, and it looks like it is missing that entry, as it only has linting entries: https://github.com/ros2/rclc/blob/master/rclc_lifecycle/package.xml#L19



Signed-off-by: Staschulat Jan <jan.staschulat@de.bosch.com>