### PR TITLE
simplified init functions. 

### DIFF
--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -109,6 +109,7 @@ rclc_executor_init(
   }
 
   rcl_ret_t ret = RCL_RET_OK;
+  (*executor) = rclc_executor_get_zero_initialized_executor();
   executor->context = context;
   executor->max_handles = number_of_handles;
   executor->index = 0;

--- a/rclc/src/rclc/node.c
+++ b/rclc/src/rclc/node.c
@@ -36,6 +36,7 @@ rclc_node_init_default(
     support, "support is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   rcl_ret_t rc = RCL_RET_OK;
+  (*node) = rcl_get_zero_initialized_node();
   rcl_node_options_t node_ops = rcl_node_get_default_options();
   rc = rclc_node_init_with_options(
     node,
@@ -69,6 +70,7 @@ rclc_node_init_with_options(
     node_ops, "support is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   rcl_ret_t rc = RCL_RET_OK;
+  (*node) = rcl_get_zero_initialized_node();
   rc = rcl_node_init(
     node,
     name,

--- a/rclc/src/rclc/publisher.c
+++ b/rclc/src/rclc/publisher.c
@@ -35,6 +35,7 @@ rclc_publisher_init_default(
   RCL_CHECK_FOR_NULL_WITH_MSG(
     topic_name, "topic_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
+  (*publisher) = rcl_get_zero_initialized_publisher();
   rcl_publisher_options_t pub_opt = rcl_publisher_get_default_options();
   rcl_ret_t rc = rcl_publisher_init(
     publisher,
@@ -64,6 +65,7 @@ rclc_publisher_init_best_effort(
   RCL_CHECK_FOR_NULL_WITH_MSG(
     topic_name, "topic_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
+  (*publisher) = rcl_get_zero_initialized_publisher();
   rcl_publisher_options_t pub_opt = rcl_publisher_get_default_options();
   pub_opt.qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
   rcl_ret_t rc = rcl_publisher_init(

--- a/rclc/src/rclc/subscription.c
+++ b/rclc/src/rclc/subscription.c
@@ -35,6 +35,7 @@ rclc_subscription_init_default(
   RCL_CHECK_FOR_NULL_WITH_MSG(
     topic_name, "topic_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
+  (*subscription) = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t sub_opt = rcl_subscription_get_default_options();
   rcl_ret_t rc = rcl_subscription_init(
     subscription,
@@ -64,6 +65,7 @@ rclc_subscription_init_best_effort(
   RCL_CHECK_FOR_NULL_WITH_MSG(
     topic_name, "topic_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
+  (*subscription) = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t sub_opt = rcl_subscription_get_default_options();
   sub_opt.qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
   rcl_ret_t rc = rcl_subscription_init(

--- a/rclc/src/rclc/timer.c
+++ b/rclc/src/rclc/timer.c
@@ -31,8 +31,8 @@ rclc_timer_init_default(
   RCL_CHECK_FOR_NULL_WITH_MSG(
     support, "support is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
-  rcl_ret_t rc = RCL_RET_OK;
-  rc = rcl_timer_init(
+  (*timer) = rcl_get_zero_initialized_timer();
+  rcl_ret_t rc = rcl_timer_init(
     timer,
     &support->clock,
     &support->context,

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -499,7 +499,6 @@ TEST_F(TestDefaultExecutor, executor_init) {
   rcl_ret_t rc;
 
   rclc_executor_t executor;
-  executor = rclc_executor_get_zero_initialized_executor();
 
   rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
@@ -530,7 +529,6 @@ TEST_F(TestDefaultExecutor, executor_init) {
 TEST_F(TestDefaultExecutor, executor_fini) {
   rcl_ret_t rc;
   rclc_executor_t executor;
-  executor = rclc_executor_get_zero_initialized_executor();
   rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
@@ -547,7 +545,6 @@ TEST_F(TestDefaultExecutor, executor_fini) {
 TEST_F(TestDefaultExecutor, executor_add_subscription) {
   rcl_ret_t rc;
   rclc_executor_t executor;
-  executor = rclc_executor_get_zero_initialized_executor();
   // test with normal arguemnt and NULL pointers as arguments
   rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
@@ -606,7 +603,6 @@ TEST_F(TestDefaultExecutor, executor_add_subscription) {
 TEST_F(TestDefaultExecutor, executor_add_subscription_too_many) {
   rcl_ret_t rc;
   rclc_executor_t executor;
-  executor = rclc_executor_get_zero_initialized_executor();
 
   // insert one handle, add two subscriptions
   rc = rclc_executor_init(&executor, &this->context, 1, this->allocator_ptr);
@@ -638,7 +634,6 @@ TEST_F(TestDefaultExecutor, executor_add_subscription_too_many) {
 TEST_F(TestDefaultExecutor, executor_add_timer) {
   rcl_ret_t rc;
   rclc_executor_t executor;
-  executor = rclc_executor_get_zero_initialized_executor();
   rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
@@ -657,7 +652,6 @@ TEST_F(TestDefaultExecutor, executor_add_timer) {
 TEST_F(TestDefaultExecutor, executor_spin_some_API) {
   rcl_ret_t rc;
   rclc_executor_t executor;
-  executor = rclc_executor_get_zero_initialized_executor();
   rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
@@ -713,7 +707,6 @@ TEST_F(TestDefaultExecutor, spin_some_sequential_execution) {
   rclc_executor_t executor;
   // initialize executor for 3 subscriptions in the order sub1, sub2, sub3
   size_t num_subscriptions = 3;
-  executor = rclc_executor_get_zero_initialized_executor();
   ret = rclc_executor_init(&executor, &this->context, num_subscriptions, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   unsigned int expected_msg;
@@ -868,7 +861,6 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   // by Jan Staschulat, under Apache 2.0 License
   rcl_ret_t ret;
   rclc_executor_t executor;
-  executor = rclc_executor_get_zero_initialized_executor();
 
   // initialize result variables
   _executor_results_init();
@@ -949,7 +941,6 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   rcl_ret_t ret;
   rclc_executor_t executor;
   // initialize executor with 2 handles
-  executor = rclc_executor_get_zero_initialized_executor();
   ret = rclc_executor_init(&executor, &this->context, 2, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   _results_callback_init();
@@ -1053,7 +1044,6 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
 TEST_F(TestDefaultExecutor, spin_period) {
   rcl_ret_t rc;
   rclc_executor_t executor;
-  executor = rclc_executor_get_zero_initialized_executor();
   // initialize executor with 1 handle
   rc = rclc_executor_init(&executor, &this->context, 1, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
@@ -1128,7 +1118,6 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
   rcl_reset_error();
 
   // initialize executor with 2 handles
-  executor = rclc_executor_get_zero_initialized_executor();
   rc = rclc_executor_init(&executor, &this->context, 2, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
@@ -1212,7 +1201,6 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
   rcl_reset_error();
 
   // initialize executor with 2 handles
-  executor = rclc_executor_get_zero_initialized_executor();
   rc = rclc_executor_init(&executor, &this->context, 2, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
@@ -1282,7 +1270,6 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   // initialize executor with 2 handles
-  executor = rclc_executor_get_zero_initialized_executor();
   rc = rclc_executor_init(&executor, &this->context, 2, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
@@ -1359,7 +1346,6 @@ TEST_F(TestDefaultExecutor, trigger_any) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   // initialize executor with 2 handles
-  executor = rclc_executor_get_zero_initialized_executor();
   rc = rclc_executor_init(&executor, &this->context, 2, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
@@ -1438,7 +1424,6 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   // initialize executor with 2 handles
-  executor = rclc_executor_get_zero_initialized_executor();
   rc = rclc_executor_init(&executor, &this->context, 2, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();
@@ -1514,7 +1499,6 @@ TEST_F(TestDefaultExecutor, trigger_always) {
   rcl_ret_t rc;
   rclc_executor_t executor;
   // initialize executor with 2 handles
-  executor = rclc_executor_get_zero_initialized_executor();
   rc = rclc_executor_init(&executor, &this->context, 2, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcl_reset_error();

--- a/rclc/test/rclc/test_node.cpp
+++ b/rclc/test/rclc/test_node.cpp
@@ -24,18 +24,13 @@ TEST(Test, rclc_node_init_default) {
   EXPECT_EQ(RCL_RET_OK, rc);
   const char * my_name = "test_node";
   const char * my_namespace = "test_namespace";
-  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_t node;
 
   // test with valid arguments
   rc = rclc_node_init_default(&node, my_name, my_namespace, &support);
   EXPECT_EQ(RCL_RET_OK, rc);
 
   // tests with invalid arguments
-
-  // test case: node already initialized
-  rc = rclc_node_init_default(&node, my_name, my_namespace, &support);
-  EXPECT_EQ(RCL_RET_ALREADY_INIT, rc);
-  rcutils_reset_error();
 
   // test case: null pointer for node
   rc = rclc_node_init_default(nullptr, my_name, my_namespace, &support);
@@ -45,7 +40,7 @@ TEST(Test, rclc_node_init_default) {
   // test case: null pointer for name
   rc = rcl_node_fini(&node);
   EXPECT_EQ(RCL_RET_OK, rc);
-  node = rcl_get_zero_initialized_node();
+
   rc = rclc_node_init_default(&node, nullptr, my_namespace, &support);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
   rcutils_reset_error();
@@ -77,7 +72,7 @@ TEST(Test, rclc_node_init_with_options) {
   EXPECT_EQ(RCL_RET_OK, rc);
   const char * my_name = "test_node";
   const char * my_namespace = "test_namespace";
-  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_t node;
   rcl_node_options_t node_options = rcl_node_get_default_options();
 
   // test with invalid arguments

--- a/rclc/test/rclc/test_publisher.cpp
+++ b/rclc/test/rclc/test_publisher.cpp
@@ -26,12 +26,12 @@ TEST(Test, rclc_publisher_init_default) {
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
   const char * my_name = "test_pub";
   const char * my_namespace = "test_namespace";
-  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_t node;
   rc = rclc_node_init_default(&node, my_name, my_namespace, &support);
   EXPECT_EQ(RCL_RET_OK, rc);
 
   // test with valid arguments
-  rcl_publisher_t publisher = rcl_get_zero_initialized_publisher();
+  rcl_publisher_t publisher;
   const rosidl_message_type_support_t * type_support =
     ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32);
   rc = rclc_publisher_init_default(&publisher, &node, type_support, "topic1");
@@ -69,11 +69,11 @@ TEST(Test, rclc_publisher_init_best_effort) {
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
   const char * my_name = "test_pub_be";
   const char * my_namespace = "test_namespace";
-  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_t node;
   rc = rclc_node_init_default(&node, my_name, my_namespace, &support);
 
   // test with valid arguments
-  rcl_publisher_t publisher = rcl_get_zero_initialized_publisher();
+  rcl_publisher_t publisher;
   const rosidl_message_type_support_t * type_support =
     ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32);
   rc = rclc_publisher_init_best_effort(&publisher, &node, type_support, "topic1");

--- a/rclc/test/rclc/test_subscription.cpp
+++ b/rclc/test/rclc/test_subscription.cpp
@@ -26,12 +26,12 @@ TEST(Test, rclc_subscription_init_default) {
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
   const char * my_name = "test_name";
   const char * my_namespace = "test_namespace";
-  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_t node;
   rc = rclc_node_init_default(&node, my_name, my_namespace, &support);
 
   // test with valid arguments
 
-  rcl_subscription_t subscription = rcl_get_zero_initialized_subscription();
+  rcl_subscription_t subscription;
   const rosidl_message_type_support_t * type_support =
     ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32);
   rc = rclc_subscription_init_default(&subscription, &node, type_support, "topic1");
@@ -69,12 +69,12 @@ TEST(Test, rclc_subscription_init_best_effort) {
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
   const char * my_name = "test_name";
   const char * my_namespace = "test_namespace";
-  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_t node;
   rc = rclc_node_init_default(&node, my_name, my_namespace, &support);
 
   // test with valid arguments
 
-  rcl_subscription_t subscription = rcl_get_zero_initialized_subscription();
+  rcl_subscription_t subscription;
   const rosidl_message_type_support_t * type_support =
     ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32);
   rc = rclc_subscription_init_best_effort(&subscription, &node, type_support, "topic1");

--- a/rclc/test/rclc/test_timer.cpp
+++ b/rclc/test/rclc/test_timer.cpp
@@ -31,12 +31,12 @@ TEST(Test, rclc_timer_init_default) {
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
   const char * my_name = "test_name";
   const char * my_namespace = "test_namespace";
-  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_t node;
   rc = rclc_node_init_default(&node, my_name, my_namespace, &support);
 
   // test with valid arguments
 
-  rcl_timer_t timer = rcl_get_zero_initialized_timer();
+  rcl_timer_t timer;
   rc = rclc_timer_init_default(&timer, &support, 10000000, my_callback);
   EXPECT_EQ(RCL_RET_OK, rc);
 

--- a/rclc_examples/src/example_executor.c
+++ b/rclc_examples/src/example_executor.c
@@ -162,7 +162,6 @@ int main(int argc, const char * argv[])
   // compute total number of subsribers and timers
   unsigned int num_handles = 1 + 1;
   printf("Debug: number of DDS handles: %u\n", num_handles);
-  executor = rclc_executor_get_zero_initialized_executor();
   rclc_executor_init(&executor, &context, num_handles, &allocator);
 
   // set timeout for rcl_wait()

--- a/rclc_examples/src/example_executor_convenience.c
+++ b/rclc_examples/src/example_executor_convenience.c
@@ -68,7 +68,7 @@ int main(int argc, const char * argv[])
   }
 
   // create rcl_node
-  rcl_node_t my_node = rcl_get_zero_initialized_node();
+  rcl_node_t my_node;
   rc = rclc_node_init_default(&my_node, "node_0", "executor_examples", &support);
   if (rc != RCL_RET_OK) {
     printf("Error in rclc_node_init_default\n");
@@ -92,7 +92,7 @@ int main(int argc, const char * argv[])
   }
 
   // create a timer, which will call the publisher with period=`timer_timeout` ms in the 'my_timer_callback'
-  rcl_timer_t my_timer = rcl_get_zero_initialized_timer();
+  rcl_timer_t my_timer;
   const unsigned int timer_timeout = 1000;
   rc = rclc_timer_init_default(
     &my_timer,

--- a/rclc_examples/src/example_executor_trigger.c
+++ b/rclc_examples/src/example_executor_trigger.c
@@ -197,7 +197,7 @@ int main(int argc, const char * argv[])
   }
 
   // create rcl_node
-  rcl_node_t my_node = rcl_get_zero_initialized_node();
+  rcl_node_t my_node;
   rc = rclc_node_init_default(&my_node, "node_0", "executor_examples", &support);
   if (rc != RCL_RET_OK) {
     printf("Error in rclc_node_init_default\n");
@@ -223,7 +223,7 @@ int main(int argc, const char * argv[])
 
   // create timer 1
   // - publishes 'my_string_pub' every 'timer_timeout' ms
-  rcl_timer_t my_string_timer = rcl_get_zero_initialized_timer();
+  rcl_timer_t my_string_timer;
   const unsigned int timer_timeout = 100;
   rc = rclc_timer_init_default(
     &my_string_timer,
@@ -255,7 +255,7 @@ int main(int argc, const char * argv[])
 
   // create timer 2
   // - publishes 'my_int_pub' every 'timer_int_timeout' ms
-  rcl_timer_t my_int_timer = rcl_get_zero_initialized_timer();
+  rcl_timer_t my_int_timer;
   const unsigned int timer_int_timeout = 10 * timer_timeout;
   rc = rclc_timer_init_default(
     &my_int_timer,
@@ -297,7 +297,7 @@ int main(int argc, const char * argv[])
 
 
   // create subscription 2
-  rcl_subscription_t my_int_sub = rcl_get_zero_initialized_subscription();
+  rcl_subscription_t my_int_sub;
   rc = rclc_subscription_init_default(
     &my_int_sub,
     &my_node,
@@ -322,7 +322,6 @@ int main(int argc, const char * argv[])
   // Executor for publishing messages
   unsigned int num_handles_pub = 2;
   printf("Executor_pub: number of DDS handles: %u\n", num_handles_pub);
-  executor_pub = rclc_executor_get_zero_initialized_executor();
   rclc_executor_init(&executor_pub, &support.context, num_handles_pub, &allocator);
 
   rc = rclc_executor_add_timer(&executor_pub, &my_string_timer);
@@ -338,7 +337,6 @@ int main(int argc, const char * argv[])
   // Executor for subscribing messages
   unsigned int num_handles_sub = 2;
   printf("Executor_sub: number of DDS handles: %u\n", num_handles_sub);
-  executor_sub = rclc_executor_get_zero_initialized_executor();
   rclc_executor_init(&executor_sub, &support.context, num_handles_sub, &allocator);
 
   // add subscription to executor

--- a/rclc_examples/src/example_lifecycle_node.c
+++ b/rclc_examples/src/example_lifecycle_node.c
@@ -67,7 +67,7 @@ int main(int argc, const char * argv[])
   }
 
   // create rcl_node
-  rcl_node_t my_node = rcl_get_zero_initialized_node();
+  rcl_node_t my_node;
   rc = rclc_node_init_default(&my_node, "lifecycle_node", "rclc", &support);
   if (rc != RCL_RET_OK) {
     printf("Error in rclc_node_init_default\n");


### PR DESCRIPTION
Not necessary any more to call rcl_get_zero_initialized_x() with x=node,publisher,subscription,timer,executor. This function is now called in the rclc_x_init*() function. 
- updated rclc library
- updated unit tests
- updated rclc_examples 
- colcon_test : passed
- executed every example of rclc_examples with ROS 2 Foxy release: passed.

Signed-off-by: Staschulat Jan <jan.staschulat@de.bosch.com>