### PR TITLE
resolving failed CI-job for eloquent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,17 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.26
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
-    #- name : Download rclc-dependencies
-    #  run: |
-    #    apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
-    #    apt-get install ros-${{ matrix.ros_distribution }}-rcl-interfaces
-    #    apt-get install ros-${{ matrix.ros_distribution }}-test-interface-files
-
-    - name : Clone rclc-dependencies
+    - name : Download and install rclc-dependencies
       run: |
-        git clone https://github.com/osrf/osrf_testing_tools_cpp src/osrf_testing_tools_cpp
-        git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/rcl_interfaces.git src/rcl_interfaces
-        git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/test_interface_files.git src/test_interface_files
+        apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
+        apt-get install ros-${{ matrix.ros_distribution }}-rcl-interfaces
+        apt-get install ros-${{ matrix.ros_distribution }}-test-interface-files
+
+    #- name : Clone rclc-dependencies
+    #  run: |
+    #    git clone https://github.com/osrf/osrf_testing_tools_cpp src/osrf_testing_tools_cpp
+    #    git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/rcl_interfaces.git src/rcl_interfaces
+    #    git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/test_interface_files.git src/test_interface_files
 
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.26
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
+    -run: apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:
         package-name: "rclc rclc_examples rclc_lifecycle"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name : Clone rclc-dependencies
       run: |
-        git clone -b ${{ matrix.ros_distribution }} https://github.com/osrf/osrf_testing_tools_cpp src/osrf_testing_tools_cpp
+        git clone https://github.com/osrf/osrf_testing_tools_cpp src/osrf_testing_tools_cpp
         git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/rcl_interfaces.git src/rcl_interfaces
         git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/test_interface_files.git src/test_interface_files
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     - name : Download and install rclc-dependencies
       run: |
         apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
-        apt-get install ros-${{ matrix.ros_distribution }}-rcl-interfaces
+        apt-get install ros-${{ matrix.ros_distribution }}-test-msgs
         apt-get install ros-${{ matrix.ros_distribution }}-test-interface-files
 
     #- name : Clone rclc-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,12 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.26
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
-    - name : Download osrf-dependency
-      run: apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
+    - name : Download rclc-dependencies
+      run: |
+        apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
+        apt-get install ros-${{ matrix.ros_distribution }}-rcl-interfaces
+        apt-get install ros-${{ matrix.ros_distribution }}-test-interface-files
+
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:
         package-name: "rclc rclc_examples rclc_lifecycle"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,17 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.26
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
-    - name : Download rclc-dependencies
+    #- name : Download rclc-dependencies
+    #  run: |
+    #    apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
+    #    apt-get install ros-${{ matrix.ros_distribution }}-rcl-interfaces
+    #    apt-get install ros-${{ matrix.ros_distribution }}-test-interface-files
+
+    - name : Clone rclc-dependencies
       run: |
-        apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
-        apt-get install ros-${{ matrix.ros_distribution }}-rcl-interfaces
-        apt-get install ros-${{ matrix.ros_distribution }}-test-interface-files
+        git clone -b ${{ matrix.ros_distribution }} https://github.com/osrf/osrf_testing_tools_cpp src/osrf_testing_tools_cpp
+        git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/rcl_interfaces.git
+        git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/test_interface_files.git
 
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
     - name : Clone rclc-dependencies
       run: |
         git clone -b ${{ matrix.ros_distribution }} https://github.com/osrf/osrf_testing_tools_cpp src/osrf_testing_tools_cpp
-        git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/rcl_interfaces.git
-        git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/test_interface_files.git
+        git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/rcl_interfaces.git src/rcl_interfaces
+        git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/test_interface_files.git src/test_interface_files
 
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
       run: |
         apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
         apt-get install ros-${{ matrix.ros_distribution }}-test-msgs
-        apt-get install ros-${{ matrix.ros_distribution }}-test-interface-files
 
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,6 @@ jobs:
         apt-get install ros-${{ matrix.ros_distribution }}-test-msgs
         apt-get install ros-${{ matrix.ros_distribution }}-test-interface-files
 
-    #- name : Clone rclc-dependencies
-    #  run: |
-    #    git clone https://github.com/osrf/osrf_testing_tools_cpp src/osrf_testing_tools_cpp
-    #    git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/rcl_interfaces.git src/rcl_interfaces
-    #    git clone -b ${{ matrix.ros_distribution }} https://github.com/ros2/test_interface_files.git src/test_interface_files
-
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:
         package-name: "rclc rclc_examples rclc_lifecycle"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.26
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
-    -run: apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
+    - name : Download osrf-dependency
+      run: apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:
         package-name: "rclc rclc_examples rclc_lifecycle"

--- a/rclc_lifecycle/CMakeLists.txt
+++ b/rclc_lifecycle/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_C_STANDARD)
 endif()
 
 # find dependencies
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(rcl_lifecycle REQUIRED)
 find_package(rclc REQUIRED)
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
     rcl_lifecycle
     rclc
     lifecycle_msgs
+    osrf_testing_tools_cpp
   )
 endif()
 


### PR DESCRIPTION
the rclc unit tests depend on these repositories (which are not in standard eloquent distribution):

- https://github.com/osrf/osrf_testing_tools_cpp.git
- https://github.com/ros2/rcl_interfaces.git which contains the package ```test_msgs```

I updated the [ci.yml](https://github.com/micro-ROS/rclc/blob/master/.github/workflows/ci.yml) file. Note, however to install the binary-package ```test_msgs``` of the repository ```rcl_interfaces```, you need to:
```apt-get install ros-DISTRO-test-msgs``` and not 
```apt-get install ros-DISTRO-rcl-interfaces```!


--- 
Alternative: specify repositories in a file and clone them, like here:
  https://github.com/boschresearch/fmi_adapter_ros2/blob/master/.github/workflows/build_and_test.yml
  https://github.com/boschresearch/fmi_adapter_ros2/blob/master/dependencies.repos 

However, this does not work for the dependencies of rclc repository:
1. osrf-testing-tools-cpp  repository does not have a ```rolling``` branch. 
2. The repo has branches for ```dashing, eloquent, foxy```. So it would need a distinction between different branches. Or try out with ```master``` branch for all ROS 2 distributions.

---
Email history:





 






Von: Staschulat Jan 

 

I found a difference in the CI job for Dashing and Eloquent in the command:

rosdep install


Dashing:

https://github.com/micro-ROS/rclc/runs/1686416342?check_suite_focus=true

The following NEW packages will be installed:
ros-dashing-osrf-testing-tools-cpp
0 upgraded, 1 newly installed, 0 to remove and 4 not upgraded.
Need to get 1,818 kB of archives.
After this operation, 2,127 kB of additional disk space will be used.
Get:1 http://packages.ros.org/ros2/ubuntu bionic/main amd64 ros-dashing-osrf-testing-tools-cpp amd64 1.2.3-1bionic.20201125.034205 [1,818 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 1,818 kB in 1s (1,938 kB/s)
Selecting previously unselected package ros-dashing-osrf-testing-tools-cpp.
(Reading database ... 



Eloquent:

https://github.com/micro-ROS/rclc/runs/1686416315?check_suite_focus=true


Invoking "bash -c 'DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths src --ignore-src --rosdistro eloquent -y || true'
/bin/bash -c DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths src --ignore-src --rosdistro eloquent -y || true
WARNING: ROS_PYTHON_VERSION is unset. Defaulting to 2
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
rclc_lifecycle: Cannot locate rosdep definition for [osrf_testing_tools_cpp]
rclc_examples: Cannot locate rosdep definition for [example_interfaces]
rclc: Cannot locate rosdep definition for [example_interfaces]
Continuing to install resolvable dependencies...
#All required rosdeps installed successfully
Invoking "bash -c 'source /opt/ros/eloquent/setup.sh && colcon build --event-handlers console_cohesion+ --packages-up-to rclc rclc_examples rclc_lifecycle --cmake-args --symlink-install'
Error: The process '/bin/bash' failed with exit code 1


Von: Lange Ralph 

Hi Jan,
 

according to https://github.com/ros-tooling/action-ros-ci#build-with-a-custom-repos-or-rosinstall-file the necessary installation step can be automated without specifying the dependencies a third time.

 

However, last summer, for fmi_adapter, I failed with these instructions and finally added the dependency explicitly to a “dependencies.repos” file referenced in the Action workflow.

 

Mit freundlichen Grüßen / Best regards

Ralph Lange


​



 
---
 

In my local machine the package osrf_testing_tools_cpp is not part of /opt/ros/dashing, /opt/ros/eloquent ... and the other versions. So I had to 'git clone' the package osrf_testing_tools_cpp locally. When building rclc locally with "colcon bulid --packages-up-to rclc_examples" then the osrf_testing_tools are also build.

 

As a test, i removed the osrf_testing_tools_cpp package from my ros2 workspace, which contains the rclc package. building for Dashing AND Eloquent failed because that package was missing.  This is interesting, because the 'colcon build' for Dashing works in the CI job at micro-ros server. Is the repository downloaded for the Dashing version?

 

The dependency for osrf_testing_tools_cpp is there in the package.xml as well as in CMakeLists.txt.

So solve the issue, we need to make sure that the workspace of the CI-job, in which the rclc repository is build, also downloads the package

 

https://github.com/osrf/osrf_testing_tools_cpp

How can this be done in the CI job specification?

---- 




Eloquent CI failing because something related with osrf_testing_tools:

https://github.com/micro-ROS/rclc/runs/1679637550?check_suite_focus=true

